### PR TITLE
NFS: ensure /etc/exports.d exists before saving file #2rpqgzk[for approval]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## Cockpit File Sharing 3.2.2-1
+## Cockpit File Sharing 3.2.3-1
 
-* Remove end of line comment in automatically inserted content of smb.conf
-* Optimize getting users and groups from domain
+* Fixed issue saving NFS exports file when /etc/exports.d DNE

--- a/file-sharing/src/components/NfsManager.vue
+++ b/file-sharing/src/components/NfsManager.vue
@@ -141,6 +141,7 @@ export default {
 
 		const writeExportsFile = async () => {
 			try {
+				await useSpawn(['mkdir', '-p', '/etc/exports.d'], { superuser: 'try' }).promise();
 				await exportsFile.replace(shares.value);
 			} catch (error) {
 				error.message = `Failed to write exports file: ${errorString(error.message)}`;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "cockpit-file-sharing",
     "title": "Cockpit File Sharing",
     "prerelease": false,
-    "version": "3.2.2",
+    "version": "3.2.3",
     "buildVersion": "1",
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "url": "https://github.com/45Drives/cockpit-file-sharing",
@@ -58,7 +58,7 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "3.2.2",
+        "version": "3.2.3",
         "buildVersion": "1",
         "ignore": [],
         "date": null,

--- a/packaging/el8/main.spec
+++ b/packaging/el8/main.spec
@@ -27,6 +27,8 @@ make DESTDIR=%{buildroot} install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Thu Aug 04 2022 Joshua Boudreau <jboudreau@45drives.com> 3.2.3-1
+- Fixed issue saving NFS exports file when /etc/exports.d DNE
 * Wed Jul 27 2022 Joshua Boudreau <jboudreau@45drives.com> 3.2.2-1
 - Remove end of line comment in automatically inserted content of smb.conf
 - Optimize getting users and groups from domain

--- a/packaging/focal/changelog
+++ b/packaging/focal/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (3.2.3-1focal) focal; urgency=medium
+
+  * Fixed issue saving NFS exports file when /etc/exports.d DNE
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Thu, 04 Aug 2022 13:06:53 -0300
+
 cockpit-file-sharing (3.2.2-1focal) focal; urgency=medium
 
   * Remove end of line comment in automatically inserted content of smb.conf


### PR DESCRIPTION
If `/etc/exports.d` does not exist (e.g. in Debian clean install), saving new share fails. Fixed by ensuring directory path exists before attempting to save the exports file.