### PR TITLE
File Sharing v3.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## Cockpit File Sharing 3.2.7-1
+## Cockpit File Sharing 3.2.8-1
 
-* Fix scrolling in Safari
+* Handle case where NFS exports.d directory does not exist.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ sudo apt install cockpit-file-sharing
 ### Direct from .deb
 Installing this way may work for other versions of Ubuntu and Debian, but it is unsupported. You won't get automatic updates this way.
 ```bash
-curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.5/cockpit-file-sharing_3.2.5-1focal_all.deb
-sudo apt install ./cockpit-file-sharing_3.2.5-1focal_all.deb
+curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.8/cockpit-file-sharing_3.2.8-1focal_all.deb
+sudo apt install ./cockpit-file-sharing_3.2.8-1focal_all.deb
 ```
 ## Rocky 8
 ### From 45Drives Repo (Recommended, Rocky 8 only)
@@ -50,7 +50,7 @@ sudo dnf install cockpit-file-sharing
 Installing this way may work for other versions of Rocky/Centos/RHEL/Fedora/etc, but it is unsupported. You won't get automatic updates this way.
 ```bash
 # dnf or yum
-sudo dnf install https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.5/cockpit-file-sharing-3.2.5-1.el8.noarch.rpm
+sudo dnf install https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.8/cockpit-file-sharing-3.2.8-1.el8.noarch.rpm
 ```
 ## Generic Installation
 1. Install Dependencies
@@ -77,9 +77,9 @@ system
 ```
 2. Download pre-built archive and install
 ```bash
-curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.5/cockpit-file-sharing_3.2.5_generic.zip
-unzip cockpit-file-sharing_3.2.5_generic.zip
-cd cockpit-file-sharing_3.2.5_generic
+curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v3.2.8/cockpit-file-sharing_3.2.8_generic.zip
+unzip cockpit-file-sharing_3.2.8_generic.zip
+cd cockpit-file-sharing_3.2.8_generic
 # no need to run `make` first, the plugin is pre-built
 sudo make install
 ```

--- a/file-sharing/src/components/NfsManager.vue
+++ b/file-sharing/src/components/NfsManager.vue
@@ -170,7 +170,7 @@ export default {
 		const loadShares = (sharesOnDisk) => {
 			processing.value++;
 			try {
-				shares.value = sharesOnDisk.sort((a, b) => a.path.localeCompare(b.path)) ?? [];
+				shares.value = sharesOnDisk?.sort((a, b) => a.path.localeCompare(b.path)) ?? [];
 			} catch (error) {
 				notifications.value.constructNotification("Failed to load share configuration", errorStringHTML(error), 'error', 0);
 			} finally {
@@ -180,6 +180,11 @@ export default {
 
 		const writeExportsFile = async () => {
 			try {
+				const filePath = config.nfs.confPath;
+				if (filePath[0] !== '/')
+					throw new Error('NFS Exports path must be absolute.');
+				const parentDir = filePath.split('/').slice(0, -1).join('/') || '/';
+				await useSpawn(['mkdir', '-p', parentDir], { superuser: 'try' }).promise();
 				await exportsFile.replace(shares.value);
 			} catch (error) {
 				error.message = `Failed to write exports file: ${errorString(error.message)}`;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "cockpit-file-sharing",
     "title": "Cockpit File Sharing",
     "prerelease": false,
-    "version": "3.2.7",
+    "version": "3.2.8",
     "buildVersion": "1",
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "url": "https://github.com/45Drives/cockpit-file-sharing",
@@ -58,7 +58,7 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "3.2.7",
+        "version": "3.2.8",
         "buildVersion": "1",
         "ignore": [],
         "date": null,

--- a/packaging/el8/main.spec
+++ b/packaging/el8/main.spec
@@ -27,6 +27,8 @@ make DESTDIR=%{buildroot} install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Mon Sep 12 2022 Joshua Boudreau <jboudreau@45drives.com> 3.2.8-1
+- Handle case where NFS exports.d directory does not exist.
 * Wed Aug 24 2022 Joshua Boudreau <jboudreau@45drives.com> 3.2.7-1
 - Fix scrolling in Safari
 * Wed Aug 24 2022 Joshua Boudreau <jboudreau@45drives.com> 3.2.6-1

--- a/packaging/focal/changelog
+++ b/packaging/focal/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (3.2.8-1focal) focal; urgency=medium
+
+  * Handle case where NFS exports.d directory does not exist.
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Mon, 12 Sep 2022 11:33:10 -0300
+
 cockpit-file-sharing (3.2.7-1focal) focal; urgency=medium
 
   * Fix scrolling in Safari


### PR DESCRIPTION
### Changes
- Handle case where exports.d directory does not exist
  - While loading shares, fixed bug in falling back to empty array if failed to read.
  - While writing exports file, creates parent directories before writing.

closes #56