### PR TITLE
Audit params users groups hotfix

### DIFF
--- a/file-sharing/src/components/SambaShareEditor.vue
+++ b/file-sharing/src/components/SambaShareEditor.vue
@@ -100,12 +100,12 @@ If not, see <https://www.gnu.org/licenses/>.
 						</button>
 					</template>
 				</template>
-				<!-- <button 
+				<button 
 					v-else
 					class="text-feedback text-primary"
 					@click="showPermissionsEditor = true"
 				>Edit
-					Permissions</button> -->
+					Permissions</button>
 				<FilePermissions
 					:show="showPermissionsEditor"
 					:path="tmpShare.path"

--- a/file-sharing/src/composables/useUserGroupLists.js
+++ b/file-sharing/src/composables/useUserGroupLists.js
@@ -43,12 +43,12 @@ const getent = (db, includeSystemAccounts) => {
 			.then(({ stdout }) => {
 				return JSON.parse(stdout);
 			}),
-		useSpawn(['bash', '-c', getentScript(db, true, includeSystemAccounts)], spawnOpts).promise()
-			.catch(state => {
-				console.warn(`Error getting users/groups from AD/domain:`, errorString(state));
-				return state;
-			})
-			.then(({ stdout }) => JSON.parse(stdout)),
+		// useSpawn(['bash', '-c', getentScript(db, true, includeSystemAccounts)], spawnOpts).promise()
+		// 	.catch(state => {
+		// 		console.warn(`Error getting users/groups from AD/domain:`, errorString(state));
+		// 		return state;
+		// 	})
+		// 	.then(({ stdout }) => JSON.parse(stdout)),
 	]).then(nested => nested.flat());
 };
 


### PR DESCRIPTION
Uncommented the "Edit Permissions" button and skipped getting list of domain users/groups to allow for permissions editing with at least local users/groups without causing hanging with large domains.
Currently untested as of opening PR.
Thoughts on changing out select dropdowns for comboboxes in permissions editor for arbitrary input?