### PR TITLE
README: Fix winbind typo for debian-like distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ nfs-kernel-server
 samba
 samba-common-bin
 systemd
-winbin
+winbind
 gawk
 # RHEL-like
 cockpit


### PR DESCRIPTION
winbin -> winbind