### PR TITLE
Workaround for Safari < 15.4 missing String.prototype.at()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## Cockpit File Sharing 3.3.4-1
+## Cockpit File Sharing 3.3.5-1
 
-* Remove AD users from Edit Permissions modal
-* Update Samba Audit parameters to conform with SnapShield requirements
+* Workaround for Safari < 15.4 missing String.prototype.at()

--- a/file-sharing/src/components/SambaShareEditor.vue
+++ b/file-sharing/src/components/SambaShareEditor.vue
@@ -501,7 +501,7 @@ export default {
 			shareValidGroups.value = [];
 			splitQuotedDelim(tmpShare["valid users"], ', ')
 				.forEach((entity) => {
-					if (entity.at(0) === '@') {
+					if (entity.charAt(0) === '@') {
 						const groupName = entity.substring(1);
 						shareValidGroups.value
 							.push(

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "cockpit-file-sharing",
     "title": "Cockpit File Sharing",
     "prerelease": false,
-    "version": "3.3.4",
+    "version": "3.3.5",
     "buildVersion": "1",
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "url": "https://github.com/45Drives/cockpit-file-sharing",
@@ -60,7 +60,7 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "3.3.4",
+        "version": "3.3.5",
         "buildVersion": "1",
         "ignore": [],
         "date": null,

--- a/packaging/el8/main.spec
+++ b/packaging/el8/main.spec
@@ -27,6 +27,8 @@ make DESTDIR=%{buildroot} install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Tue Mar 12 2024 Joshua Boudreau <jboudreau@45drives.com> 3.3.5-1
+- Workaround for Safari < 15.4 missing String.prototype.at()
 * Fri Jun 02 2023 Dawson Della Valle <ddellavalle@45drives.com> 3.3.4-1
 - Remove AD users from Edit Permissions modal
 - Update Samba Audit parameters to conform with SnapShield requirements

--- a/packaging/focal/changelog
+++ b/packaging/focal/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (3.3.5-1focal) focal; urgency=medium
+
+  * Workaround for Safari < 15.4 missing String.prototype.at()
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Tue, 12 Mar 2024 13:12:02 -0300
+
 cockpit-file-sharing (3.3.4-1focal) focal; urgency=medium
 
   * Remove AD users from Edit Permissions modal


### PR DESCRIPTION
https://caniuse.com/mdn-javascript_builtins_string_at