### PR TITLE
Bugfix nfs ceph remount remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-## Cockpit File Sharing 4.3.2-1
+## Cockpit File Sharing 4.3.2-2
 
 * Fix bug causing nfs server crash during export removal with ceph by removing ceph remount after removing share instead of before
+* Fix bug causing NFS hooks to be run multiple times for clustered environments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## Cockpit File Sharing 4.3.1-2
+## Cockpit File Sharing 4.3.2-1
 
-* Fix os release display in app info popup on EL8/EL9
-* Enable AD accounts what's new popup for v4.3.1
+* Fix bug causing nfs server crash during export removal with ceph by removing ceph remount after removing share instead of before

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ sudo apt install cockpit-file-sharing
 ### Direct from .deb
 Installing this way may work for other versions of Ubuntu and Debian, but it is unsupported. You won't get automatic updates this way.
 ```bash
-curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v4.3.1/cockpit-file-sharing_4.3.1-2focal_all.deb
-sudo apt install ./cockpit-file-sharing_4.3.1-2focal_all.deb
+curl -LO https://github.com/45Drives/cockpit-file-sharing/releases/download/v4.3.2/cockpit-file-sharing_4.3.2-2focal_all.deb
+sudo apt install ./cockpit-file-sharing_4.3.2-2focal_all.deb
 ```
 ## Rocky 8
 ### From 45Drives Repo (Recommended, Rocky 8 only)
@@ -51,7 +51,7 @@ sudo dnf install cockpit-file-sharing
 Installing this way may work for other versions of Rocky/Centos/RHEL/Fedora/etc, but it is unsupported. You won't get automatic updates this way.
 ```bash
 # dnf or yum
-sudo dnf install https://github.com/45Drives/cockpit-file-sharing/releases/download/v4.3.1/cockpit-file-sharing-4.3.1-2.el8.noarch.rpm
+sudo dnf install https://github.com/45Drives/cockpit-file-sharing/releases/download/v4.3.2/cockpit-file-sharing-4.3.2-2.el8.noarch.rpm
 ```
 ## Generic Installation
 1. Install Dependencies

--- a/file-sharing/src/common/ui/CephOptions.vue
+++ b/file-sharing/src/common/ui/CephOptions.vue
@@ -207,7 +207,7 @@ useHookCallback([Hooks.BeforeAddShare, Hooks.BeforeEditShare], (_, share) => {
   return ResultAsync.combine(results).map(() => {});
 });
 
-useHookCallback(Hooks.BeforeRemoveShare, (_server, share) => {
+useHookCallback(Hooks.AfterRemoveShare, (_server, share) => {
   if (
     share.path != path.value ||
     !(currentOptions.remounted && remountManagedByFileSharing.value)

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,9 @@
     "name": "cockpit-file-sharing",
     "title": "Cockpit File Sharing",
     "description": "A cockpit module to make file sharing with Samba and NFS easier.",
-    "version": "4.3.1",
-    "build_number": "2",
-    "stable": true,
+    "version": "4.3.2",
+    "build_number": "1",
+    "stable": false,
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-file-sharing",
     "license": "GPL-3.0+",
@@ -75,8 +75,8 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "4.3.1",
-        "build_number": "2",
+        "version": "4.3.2",
+        "build_number": "1",
         "date": null,
         "packager": "Josh Boudreau <jboudreau@45drives.com>",
         "changes": []

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": "A cockpit module to make file sharing with Samba and NFS easier.",
     "version": "4.3.2",
     "build_number": "2",
-    "stable": false,
+    "stable": true,
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-file-sharing",
     "license": "GPL-3.0+",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "title": "Cockpit File Sharing",
     "description": "A cockpit module to make file sharing with Samba and NFS easier.",
     "version": "4.3.2",
-    "build_number": "1",
+    "build_number": "2",
     "stable": false,
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-file-sharing",
@@ -76,7 +76,7 @@
     "changelog": {
         "urgency": "medium",
         "version": "4.3.2",
-        "build_number": "1",
+        "build_number": "2",
         "date": null,
         "packager": "Josh Boudreau <jboudreau@45drives.com>",
         "changes": []

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,11 @@
+cockpit-file-sharing (4.3.2-2bookworm) bookworm; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+  * Fix bug causing NFS hooks to be run multiple times for clustered environments
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Fri, 19 Sep 2025 11:33:07 -0300
+
 cockpit-file-sharing (4.3.2-1bookworm) bookworm; urgency=medium
 
   * Fix bug causing nfs server crash during export removal with ceph by removing

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,10 @@
+cockpit-file-sharing (4.3.2-1bookworm) bookworm; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Mon, 08 Sep 2025 13:27:59 -0300
+
 cockpit-file-sharing (4.3.1-2bookworm) bookworm; urgency=medium
 
   * Fix os release display in app info popup on EL8/EL9

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -28,6 +28,10 @@ make DESTDIR=%{buildroot} OS_PACKAGE_RELEASE=el8 install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Fri Sep 19 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-2
+- Fix bug causing nfs server crash during export removal with ceph by removing ceph
+  remount after removing share instead of before
+- Fix bug causing NFS hooks to be run multiple times for clustered environments
 * Mon Sep 08 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-1
 - Fix bug causing nfs server crash during export removal with ceph by removing ceph
   remount after removing share instead of before

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -28,6 +28,9 @@ make DESTDIR=%{buildroot} OS_PACKAGE_RELEASE=el8 install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Mon Sep 08 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-1
+- Fix bug causing nfs server crash during export removal with ceph by removing ceph
+  remount after removing share instead of before
 * Mon Aug 25 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.1-2
 - Fix os release display in app info popup on EL8/EL9
 - Enable AD accounts what's new popup for v4.3.1

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -28,6 +28,9 @@ make DESTDIR=%{buildroot} OS_PACKAGE_RELEASE=el9 install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Mon Sep 08 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-1
+- Fix bug causing nfs server crash during export removal with ceph by removing ceph
+  remount after removing share instead of before
 * Mon Aug 25 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.1-2
 - Fix os release display in app info popup on EL8/EL9
 - Enable AD accounts what's new popup for v4.3.1

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -28,6 +28,10 @@ make DESTDIR=%{buildroot} OS_PACKAGE_RELEASE=el9 install
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Fri Sep 19 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-2
+- Fix bug causing nfs server crash during export removal with ceph by removing ceph
+  remount after removing share instead of before
+- Fix bug causing NFS hooks to be run multiple times for clustered environments
 * Mon Sep 08 2025 Joshua Boudreau <jboudreau@45drives.com> 4.3.2-1
 - Fix bug causing nfs server crash during export removal with ceph by removing ceph
   remount after removing share instead of before

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,10 @@
+cockpit-file-sharing (4.3.2-1focal) focal; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Mon, 08 Sep 2025 13:27:59 -0300
+
 cockpit-file-sharing (4.3.1-2focal) focal; urgency=medium
 
   * Fix os release display in app info popup on EL8/EL9

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,11 @@
+cockpit-file-sharing (4.3.2-2focal) focal; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+  * Fix bug causing NFS hooks to be run multiple times for clustered environments
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Fri, 19 Sep 2025 11:33:07 -0300
+
 cockpit-file-sharing (4.3.2-1focal) focal; urgency=medium
 
   * Fix bug causing nfs server crash during export removal with ceph by removing

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,11 @@
+cockpit-file-sharing (4.3.2-2jammy) jammy; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+  * Fix bug causing NFS hooks to be run multiple times for clustered environments
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Fri, 19 Sep 2025 11:33:07 -0300
+
 cockpit-file-sharing (4.3.2-1jammy) jammy; urgency=medium
 
   * Fix bug causing nfs server crash during export removal with ceph by removing

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,10 @@
+cockpit-file-sharing (4.3.2-1jammy) jammy; urgency=medium
+
+  * Fix bug causing nfs server crash during export removal with ceph by removing
+    ceph remount after removing share instead of before
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Mon, 08 Sep 2025 13:27:59 -0300
+
 cockpit-file-sharing (4.3.1-2jammy) jammy; urgency=medium
 
   * Fix os release display in app info popup on EL8/EL9


### PR DESCRIPTION
* Fix bug causing nfs server crash during export removal with ceph by removing ceph remount after removing share instead of before
* Fix bug causing NFS hooks to be run multiple times for clustered environments