### PR TITLE
iSCSI: run SCST operations via Cockpit superuser

### DIFF
--- a/file-sharing/src/App.vue
+++ b/file-sharing/src/App.vue
@@ -51,7 +51,7 @@ const nfsConfigured = (): ResultAsync<boolean, never> => {
 
 const iscsiConfigured = (): ResultAsync<boolean, never> => {
   return getServer()
-    .andThen((server) => new Directory(server, "/sys/kernel/scst_tgt").exists())
+    .andThen((server) => new Directory(server, "/sys/kernel/scst_tgt").exists({ superuser: "try" }))
     .orElse((_) => ok(false));
 };
 

--- a/file-sharing/src/tabs/iSCSI/types/ConfigurationManager.ts
+++ b/file-sharing/src/tabs/iSCSI/types/ConfigurationManager.ts
@@ -18,7 +18,7 @@ export class ConfigurationManager {
                             new BashCommand(
                                 `scstadmin -write_config ${userSettings.value.iscsi.confPath}`,
                                 [],
-                                { superuser: "require" }
+                                { superuser: "try" }
                             )
             )
             .andThen(() =>
@@ -27,7 +27,7 @@ export class ConfigurationManager {
                                     new BashCommand(
                                         `cat ${userSettings.value.iscsi.confPath}`,
                                         [],
-                                        { superuser: "require" }
+                                        { superuser: "try" }
                                     )
                                 )
                 .map((proc) => proc.getStdout())
@@ -38,14 +38,14 @@ export class ConfigurationManager {
     importConfiguration(newConfig: string) {
         return userSettingsResult.andThen((userSettings) => {
             return new File(this.server, userSettings.value.iscsi.confPath)
-                                .create(false, { superuser: "require" })
-                                .andThen((file) => file.write(newConfig, { superuser: "require" }))
+                                .create(false, { superuser: "try" })
+                                .andThen((file) => file.write(newConfig, { superuser: "try" }))
                                 .andThen(() =>
                                     this.server.execute(
                                         new BashCommand(
                                             `scstadmin -check_config ${userSettings.value.iscsi.confPath}`,
                                             [],
-                                            { superuser: "require" }
+                                            { superuser: "try" }
                                         )
                                     )
                                 )
@@ -54,7 +54,7 @@ export class ConfigurationManager {
                                         new BashCommand(
                                             `scstadmin -config ${userSettings.value.iscsi.confPath} -force -noprompt`,
                                             [],
-                                            { superuser: "require" }
+                                            { superuser: "try" }
                                         )
                                     )
                                 )
@@ -65,13 +65,13 @@ export class ConfigurationManager {
     saveCurrentConfiguration(): ResultAsync<File, ProcessError> {
         return userSettingsResult.andThen((userSettings) => {
             return new File(this.server, userSettings.value.iscsi.confPath)
-                                .create(true, { superuser: "require" })
+                                .create(true, { superuser: "try" })
                 .andThen((file) =>
                     this.exportConfiguration()
-                                                .andThen((config) => file.write(config, { superuser: "require" }))
+                                                .andThen((config) => file.write(config, { superuser: "try" }))
                                                 .andThen(() =>
                                                     this.server.execute(
-                                                        new BashCommand(`systemctl enable scst`, [], { superuser: "require" })
+                                                        new BashCommand(`systemctl enable scst`, [], { superuser: "try" })
                                                     )
                                                 )
                                                 .andThen(() =>
@@ -79,7 +79,7 @@ export class ConfigurationManager {
                                                         new BashCommand(
                                                             `scstadmin -config ${userSettings.value.iscsi.confPath}`,
                                                             [],
-                                                            { superuser: "require" }
+                                                            { superuser: "try" }
                                                         )
                                                     )
                                                 )

--- a/file-sharing/src/tabs/iSCSI/types/ConfigurationManager.ts
+++ b/file-sharing/src/tabs/iSCSI/types/ConfigurationManager.ts
@@ -15,11 +15,21 @@ export class ConfigurationManager {
         return userSettingsResult.andThen((userSettings) => {
           return this.server
             .execute(
-              new BashCommand(`scstadmin -write_config ${userSettings.value.iscsi.confPath}`)
+                            new BashCommand(
+                                `scstadmin -write_config ${userSettings.value.iscsi.confPath}`,
+                                [],
+                                { superuser: "require" }
+                            )
             )
             .andThen(() =>
               this.server
-                .execute(new BashCommand(`cat ${userSettings.value.iscsi.confPath}`))
+                                .execute(
+                                    new BashCommand(
+                                        `cat ${userSettings.value.iscsi.confPath}`,
+                                        [],
+                                        { superuser: "require" }
+                                    )
+                                )
                 .map((proc) => proc.getStdout())
             );
         });
@@ -28,10 +38,26 @@ export class ConfigurationManager {
     importConfiguration(newConfig: string) {
         return userSettingsResult.andThen((userSettings) => {
             return new File(this.server, userSettings.value.iscsi.confPath)
-                .create()
-                .andThen((file) => file.write(newConfig))
-                .andThen(() => this.server.execute(new BashCommand(`scstadmin -check_config ${userSettings.value.iscsi.confPath}`)))
-                .map(() => this.server.execute(new BashCommand(`scstadmin -config ${userSettings.value.iscsi.confPath} -force -noprompt`)))
+                                .create(false, { superuser: "require" })
+                                .andThen((file) => file.write(newConfig, { superuser: "require" }))
+                                .andThen(() =>
+                                    this.server.execute(
+                                        new BashCommand(
+                                            `scstadmin -check_config ${userSettings.value.iscsi.confPath}`,
+                                            [],
+                                            { superuser: "require" }
+                                        )
+                                    )
+                                )
+                                .andThen(() =>
+                                    this.server.execute(
+                                        new BashCommand(
+                                            `scstadmin -config ${userSettings.value.iscsi.confPath} -force -noprompt`,
+                                            [],
+                                            { superuser: "require" }
+                                        )
+                                    )
+                                )
                 .mapErr(() => new ProcessError("Config file syntax validation failed."))
         });
     }
@@ -39,12 +65,24 @@ export class ConfigurationManager {
     saveCurrentConfiguration(): ResultAsync<File, ProcessError> {
         return userSettingsResult.andThen((userSettings) => {
             return new File(this.server, userSettings.value.iscsi.confPath)
-                .create(true)
+                                .create(true, { superuser: "require" })
                 .andThen((file) =>
                     this.exportConfiguration()
-                        .map((config) => file.write(config))
-                        .andThen(() => this.server.execute(new BashCommand(`systemctl enable scst`)))
-                        .andThen(() => this.server.execute(new BashCommand(`scstadmin -config ${userSettings.value.iscsi.confPath}`)))
+                                                .andThen((config) => file.write(config, { superuser: "require" }))
+                                                .andThen(() =>
+                                                    this.server.execute(
+                                                        new BashCommand(`systemctl enable scst`, [], { superuser: "require" })
+                                                    )
+                                                )
+                                                .andThen(() =>
+                                                    this.server.execute(
+                                                        new BashCommand(
+                                                            `scstadmin -config ${userSettings.value.iscsi.confPath}`,
+                                                            [],
+                                                            { superuser: "require" }
+                                                        )
+                                                    )
+                                                )
                         .map(() => file)
                 );
         });

--- a/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverClusteredServer.ts
+++ b/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverClusteredServer.ts
@@ -64,7 +64,7 @@ export class ISCSIDriverClusteredServer implements ISCSIDriver {
     // console.log(" primary constructor server ", server);
   }
   initialize() {
-    return new Directory(this.server, "/sys/kernel/scst_tgt").exists().andThen((exists) => {
+    return new Directory(this.server, "/sys/kernel/scst_tgt").exists({ superuser: "try" }).andThen((exists) => {
       if (!exists) {
         return err(new ProcessError("/sys/kernel/scst_tgt was not found. Is SCST installed?"));
       }

--- a/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverSingleServer.ts
+++ b/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverSingleServer.ts
@@ -45,7 +45,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add_device $1 $2" > $3`,
             [virtualDevice.deviceName, "filename=" + virtualDevice.filePath + ";blocksize=" + virtualDevice.blockSize, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -55,7 +55,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del_device $1" > $2`,
             [virtualDevice.deviceName, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -65,10 +65,10 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add_target $1" > $2`,
             [target.name, this.targetManagementDirectory + "/mgmt"],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
-        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [this.targetManagementDirectory + "/enabled"], { superuser: "require" })))
-        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [`${this.targetManagementDirectory}/${target.name}/enabled`], { superuser: "require" })))
+        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [this.targetManagementDirectory + "/enabled"], { superuser: "try" })))
+        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [`${this.targetManagementDirectory}/${target.name}/enabled`], { superuser: "try" })))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
@@ -77,7 +77,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del_target $1" > $2`,
             [target.name, this.targetManagementDirectory + "/mgmt"],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -87,7 +87,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add_target_attribute $1 $2" > $3`,
             [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -97,7 +97,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del_target_attribute $1 $2" > $3`,
             [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -107,7 +107,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "create $1" > $2`,
             [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -117,7 +117,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del $1" > $2`,
             [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -127,7 +127,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add $1" > $2`,
             [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -137,7 +137,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del $1" > $2`,
             [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -147,7 +147,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add $1 $2" > $3`,
             [logicalUnitNumber.name, logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -157,7 +157,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "del $1" > $2`,
             [logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -167,7 +167,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server.execute(new BashCommand(
             `echo "add_target_attribute $1 $2" > $3`,
             [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username} ${chapConfiguration.password}`, `${this.getTargetPath(target)}/../mgmt`],
-            { superuser: "require" }
+            { superuser: "try" }
         ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -177,7 +177,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
                 return this.server.execute(new BashCommand(
                         `echo "del_target_attribute $1 $2" > $3`,
                         [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username}`, `${this.getTargetPath(target)}/../mgmt`],
-                        { superuser: "require" }
+                        { superuser: "try" }
                 ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
@@ -186,7 +186,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server
           .execute(
             new Command(["bash","-lc","cat /sys/kernel/scst_tgt/targets/iscsi/*/ini_groups/*/luns/*/device/prod_id 2>/dev/null || true",
-                        ], { superuser: "require" })
+                        ], { superuser: "try" })
           )
           .map((proc) => {
             const names = proc
@@ -216,7 +216,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
       
 
     getVirtualDevicesOfDeviceType(deviceType: DeviceType): ResultAsync<VirtualDevice[], ProcessError> { 
-        return this.server.execute(new Command(["find", this.deviceTypeToHandlerDirectory[deviceType], ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", this.deviceTypeToHandlerDirectory[deviceType], ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const virtualDeviceNames = proc.getStdout().split("\0").slice(0, -1);
                 return virtualDeviceNames;
@@ -225,7 +225,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
             return ResultAsync.combine(virtualDeviceNames.map((virtualDeviceName) => {
                 const virtualDevicePath = this.deviceTypeToHandlerDirectory[deviceType] + "/" + virtualDeviceName;
 
-                const blockSizeResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/blocksize"], { superuser: "require" })).andThen((proc) => {
+                const blockSizeResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/blocksize"], { superuser: "try" })).andThen((proc) => {
                     const blockSizeString = proc.getStdout().trim();
                     const maybeBlockSize = StringToIntCaster()(blockSizeString);
 
@@ -235,7 +235,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
                     return ok(maybeBlockSize.some());
                 }); 
                 
-                const filePathResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/filename"], { superuser: "require" })).andThen((proc) => {
+                const filePathResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/filename"], { superuser: "try" })).andThen((proc) => {
                     const filePathString = proc.getStdout().split('\n')[0];
     
                     if (filePathString === undefined)
@@ -255,7 +255,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         
         const targetDirectory = "/sys/kernel/scst_tgt/targets/iscsi";
 
-        return this.server.execute(new Command(["find", targetDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", targetDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const targetNames = proc.getStdout().split("\0").slice(0, -1);
                 return targetNames;
@@ -281,7 +281,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     getPortalsOfTarget(target: Pick<Target, "name">): ResultAsync<Portal[], ProcessError> {
-        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-name allowed_portal* -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-name allowed_portal* -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const portalAddressFileNames = proc.getStdout().split("\0").slice(0, -1);
                 return portalAddressFileNames;
@@ -289,7 +289,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         ).andThen((portalAddressFileNames) => {
             const addressResults = portalAddressFileNames.map((portalAddressFileName) => {
                 const file = new File(this.server, `${this.getTargetPath(target)}/${portalAddressFileName}`)
-                return file.read({ superuser: "require" }).andThen((fileContent) => {
+                return file.read({ superuser: "try" }).andThen((fileContent) => {
                     const address = fileContent.split('\n')[0]
 
                     if (address === undefined)
@@ -307,7 +307,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         const self = this;
         const initiatorGroupDirectory = `${this.getTargetPath(target)}/ini_groups`;
 
-        return this.server.execute(new Command(["find", initiatorGroupDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", initiatorGroupDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const groupNames = proc.getStdout().split("\0").slice(0, -1);
                 return groupNames;
@@ -336,11 +336,11 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const sessionsDirectory = `${this.getTargetPath(target)}/sessions`;
 
-        return new Directory(this.server, sessionsDirectory).exists({ superuser: "require" })
+        return new Directory(this.server, sessionsDirectory).exists({ superuser: "try" })
         .andThen((exists) => {
             if (exists)
             {
-                return this.server.execute(new Command(["find", sessionsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" }))
+                return this.server.execute(new Command(["find", sessionsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "try" }))
                 .map((proc) => proc.getStdout().split("\0").slice(0, -1))
                 .andThen((initiatorNames) => {
                     return ResultAsync.combine(initiatorNames.map((initiatorName) => {
@@ -352,8 +352,8 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         
                             return ok<Session>({
                                 ...partialSession,
-                                readAmountKB:  StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/read_io_count_kb`], { superuser: "require" })).safeUnwrap()).getStdout()).some(),
-                                writeAmountKB: StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/write_io_count_kb`], { superuser: "require" })).safeUnwrap()).getStdout()).some(),
+                                readAmountKB:  StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/read_io_count_kb`], { superuser: "try" })).safeUnwrap()).getStdout()).some(),
+                                writeAmountKB: StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/write_io_count_kb`], { superuser: "try" })).safeUnwrap()).getStdout()).some(),
                                 connections: yield * self.getConnectionsOfSession(partialSession).safeUnwrap(),
                             });
                         }))
@@ -367,13 +367,13 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     getCHAPConfigurationsOfTarget(target: Pick<Target, "name">): ResultAsync<CHAPConfiguration[], ProcessError> {
-        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-type f ( -name IncomingUser* -o -name OutgoingUser* ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-type f ( -name IncomingUser* -o -name OutgoingUser* ) -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => proc.getStdout().split("\0").slice(0, -1)
         ).andThen((configurationFileNames) => {
             return ResultAsync.combine(configurationFileNames.map((configurationFileName) => {
                 const file = new File(this.server, `${this.getTargetPath(target)}/${configurationFileName}`);
                 
-                return file.read({ superuser: "require" }).andThen((fileContent) => {
+                return file.read({ superuser: "try" }).andThen((fileContent) => {
                     const credentialLine = fileContent.split('\n')[0]
 
                     if (credentialLine === undefined)
@@ -401,7 +401,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const ignoredNames = ["latency", "lun", "."];
 
-        return this.server.execute(new Command(["find", `${session.devicePath}/`, ..."-type d -mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", `${session.devicePath}/`, ..."-type d -mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const connectionFileNames = proc.getStdout().split("\0").slice(0, -1);
                 return connectionFileNames.filter(directoryName => 
@@ -421,8 +421,8 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
                     return ok<Connection>({
                         ...partialConnection,
-                        connectionID: yield * connectionIDFile.read({ superuser: "require" }).safeUnwrap(),
-                        ipAddress: yield * ipFile.read({ superuser: "require" }).safeUnwrap(),
+                        connectionID: yield * connectionIDFile.read({ superuser: "try" }).safeUnwrap(),
+                        ipAddress: yield * ipFile.read({ superuser: "try" }).safeUnwrap(),
                     });
                 }))
             }))
@@ -434,7 +434,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const lunsDirectory = `${initiatorGroup.devicePath}/luns`;
 
-        return this.server.execute(new Command(["find", lunsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", lunsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 return proc.getStdout().split("\0").slice(0, -1);
             }
@@ -445,7 +445,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
                         unitNumber: StringToIntCaster()(number).some(),
                     };
 
-                    const lunDeviceName = (yield * self.server.execute(new Command(["cat", `${lunsDirectory}/${partialLogicalUnitNumber.unitNumber}/device/prod_id`], { superuser: "require" })).safeUnwrap()).getStdout();
+                    const lunDeviceName = (yield * self.server.execute(new Command(["cat", `${lunsDirectory}/${partialLogicalUnitNumber.unitNumber}/device/prod_id`], { superuser: "try" })).safeUnwrap()).getStdout();
                     const device = (yield * self.getVirtualDevices().safeUnwrap()).find((device) => device.deviceName === lunDeviceName);
 
                     return ok<LogicalUnitNumber>({
@@ -463,7 +463,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const initiatorDirectory = `${initiatorGroup.devicePath}/initiators`;
 
-        return this.server.execute(new Command(["find", initiatorDirectory, ..."-mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "require" })).map(
+        return this.server.execute(new Command(["find", initiatorDirectory, ..."-mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "try" })).map(
             (proc) => {
                 const initiatorNames = proc.getStdout().split("\0").slice(0, -1);
                 return initiatorNames.filter(name => !ignoredNames.includes(name));

--- a/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverSingleServer.ts
+++ b/file-sharing/src/tabs/iSCSI/types/drivers/ISCSIDriverSingleServer.ts
@@ -31,7 +31,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     initialize(): ResultAsync<ISCSIDriver, ProcessError> {
-        return new Directory(this.server, "/sys/kernel/scst_tgt").exists()
+        return new Directory(this.server, "/sys/kernel/scst_tgt").exists({ superuser: "try" })
         .andThen((exists) => {
             return exists ? ok(this) : err(new ProcessError("/sys/kernel/scst_tgt was not found. Is SCST installed?"));
         })
@@ -42,87 +42,143 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     addVirtualDevice(virtualDevice: VirtualDevice): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add_device $1 $2" > $3`, [virtualDevice.deviceName, "filename=" + virtualDevice.filePath + ";blocksize=" + virtualDevice.blockSize, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"]))
+        return this.server.execute(new BashCommand(
+            `echo "add_device $1 $2" > $3`,
+            [virtualDevice.deviceName, "filename=" + virtualDevice.filePath + ";blocksize=" + virtualDevice.blockSize, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     removeVirtualDevice(virtualDevice: VirtualDevice): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del_device $1" > $2`, [virtualDevice.deviceName, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"]))
+        return this.server.execute(new BashCommand(
+            `echo "del_device $1" > $2`,
+            [virtualDevice.deviceName, this.deviceTypeToHandlerDirectory[virtualDevice.deviceType] + "/mgmt"],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     createTarget(target: Target): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add_target $1" > $2`, [target.name, this.targetManagementDirectory + "/mgmt"]))
-        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [this.targetManagementDirectory + "/enabled"])))
-        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [`${this.targetManagementDirectory}/${target.name}/enabled`])))
+        return this.server.execute(new BashCommand(
+            `echo "add_target $1" > $2`,
+            [target.name, this.targetManagementDirectory + "/mgmt"],
+            { superuser: "require" }
+        ))
+        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [this.targetManagementDirectory + "/enabled"], { superuser: "require" })))
+        .andThen(() => this.server.execute(new BashCommand(`echo 1 > $1`, [`${this.targetManagementDirectory}/${target.name}/enabled`], { superuser: "require" })))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     removeTarget(target: Target): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del_target $1" > $2`, [target.name, this.targetManagementDirectory + "/mgmt"]))
+        return this.server.execute(new BashCommand(
+            `echo "del_target $1" > $2`,
+            [target.name, this.targetManagementDirectory + "/mgmt"],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     addPortalToTarget(target: Target, portal: Portal): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add_target_attribute $1 $2" > $3`, [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "add_target_attribute $1 $2" > $3`,
+            [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     deletePortalFromTarget(target: Target, portal: Portal): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del_target_attribute $1 $2" > $3`, [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "del_target_attribute $1 $2" > $3`,
+            [target.name, `allowed_portal=${portal.address}`, `${this.getTargetPath(target)}/../mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     addInitiatorGroupToTarget(target: Target, initiatorGroup: InitiatorGroup): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "create $1" > $2`, [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "create $1" > $2`,
+            [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     deleteInitiatorGroupFromTarget(target: Target, initiatorGroup: InitiatorGroup): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del $1" > $2`, [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "del $1" > $2`,
+            [initiatorGroup.name, `${this.getTargetPath(target)}/ini_groups/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     addInitiatorToGroup(initiatorGroup: InitiatorGroup, initiator: Initiator): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add $1" > $2`, [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "add $1" > $2`,
+            [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     removeInitiatorFromGroup(initiatorGroup: InitiatorGroup, initiator: Initiator): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del $1" > $2`, [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "del $1" > $2`,
+            [initiator.name, `${initiatorGroup.devicePath}/initiators/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     addLogicalUnitNumberToGroup(initiatorGroup: InitiatorGroup, logicalUnitNumber: LogicalUnitNumber): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add $1 $2" > $3`, [logicalUnitNumber.name, logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "add $1 $2" > $3`,
+            [logicalUnitNumber.name, logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     removeLogicalUnitNumberFromGroup(initiatorGroup: InitiatorGroup, logicalUnitNumber: LogicalUnitNumber): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del $1" > $2`, [logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "del $1" > $2`,
+            [logicalUnitNumber.unitNumber.toString(), `${initiatorGroup.devicePath}/luns/mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     addCHAPConfigurationToTarget(target: Target, chapConfiguration: CHAPConfiguration): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "add_target_attribute $1 $2" > $3`, [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username} ${chapConfiguration.password}`, `${this.getTargetPath(target)}/../mgmt`]))
+        return this.server.execute(new BashCommand(
+            `echo "add_target_attribute $1 $2" > $3`,
+            [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username} ${chapConfiguration.password}`, `${this.getTargetPath(target)}/../mgmt`],
+            { superuser: "require" }
+        ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
 
     removeCHAPConfigurationFromTarget(target: Target, chapConfiguration: CHAPConfiguration): ResultAsync<void, ProcessError> {
-        return this.server.execute(new BashCommand(`echo "del_target_attribute $1 $2" > $3`, [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username}`, `${this.getTargetPath(target)}/../mgmt`]))
+                return this.server.execute(new BashCommand(
+                        `echo "del_target_attribute $1 $2" > $3`,
+                        [target.name, `${chapConfiguration.chapType}=${chapConfiguration.username}`, `${this.getTargetPath(target)}/../mgmt`],
+                        { superuser: "require" }
+                ))
         .andThen(() => this.configurationManager.saveCurrentConfiguration())
         .map(() => undefined);
     }
@@ -130,7 +186,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         return this.server
           .execute(
             new Command(["bash","-lc","cat /sys/kernel/scst_tgt/targets/iscsi/*/ini_groups/*/luns/*/device/prod_id 2>/dev/null || true",
-            ])
+                        ], { superuser: "require" })
           )
           .map((proc) => {
             const names = proc
@@ -160,7 +216,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
       
 
     getVirtualDevicesOfDeviceType(deviceType: DeviceType): ResultAsync<VirtualDevice[], ProcessError> { 
-        return this.server.execute(new Command(["find", this.deviceTypeToHandlerDirectory[deviceType], ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", this.deviceTypeToHandlerDirectory[deviceType], ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const virtualDeviceNames = proc.getStdout().split("\0").slice(0, -1);
                 return virtualDeviceNames;
@@ -169,7 +225,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
             return ResultAsync.combine(virtualDeviceNames.map((virtualDeviceName) => {
                 const virtualDevicePath = this.deviceTypeToHandlerDirectory[deviceType] + "/" + virtualDeviceName;
 
-                const blockSizeResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/blocksize"])).andThen((proc) => {
+                const blockSizeResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/blocksize"], { superuser: "require" })).andThen((proc) => {
                     const blockSizeString = proc.getStdout().trim();
                     const maybeBlockSize = StringToIntCaster()(blockSizeString);
 
@@ -179,7 +235,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
                     return ok(maybeBlockSize.some());
                 }); 
                 
-                const filePathResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/filename"])).andThen((proc) => {
+                const filePathResult =  this.server.execute(new Command(["cat", virtualDevicePath + "/filename"], { superuser: "require" })).andThen((proc) => {
                     const filePathString = proc.getStdout().split('\n')[0];
     
                     if (filePathString === undefined)
@@ -199,7 +255,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         
         const targetDirectory = "/sys/kernel/scst_tgt/targets/iscsi";
 
-        return this.server.execute(new Command(["find", targetDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", targetDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const targetNames = proc.getStdout().split("\0").slice(0, -1);
                 return targetNames;
@@ -225,7 +281,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     getPortalsOfTarget(target: Pick<Target, "name">): ResultAsync<Portal[], ProcessError> {
-        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-name allowed_portal* -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-name allowed_portal* -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const portalAddressFileNames = proc.getStdout().split("\0").slice(0, -1);
                 return portalAddressFileNames;
@@ -233,7 +289,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         ).andThen((portalAddressFileNames) => {
             const addressResults = portalAddressFileNames.map((portalAddressFileName) => {
                 const file = new File(this.server, `${this.getTargetPath(target)}/${portalAddressFileName}`)
-                return file.read().andThen((fileContent) => {
+                return file.read({ superuser: "require" }).andThen((fileContent) => {
                     const address = fileContent.split('\n')[0]
 
                     if (address === undefined)
@@ -251,7 +307,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         const self = this;
         const initiatorGroupDirectory = `${this.getTargetPath(target)}/ini_groups`;
 
-        return this.server.execute(new Command(["find", initiatorGroupDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", initiatorGroupDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const groupNames = proc.getStdout().split("\0").slice(0, -1);
                 return groupNames;
@@ -280,11 +336,11 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const sessionsDirectory = `${this.getTargetPath(target)}/sessions`;
 
-        return new Directory(this.server, sessionsDirectory).exists()
+        return new Directory(this.server, sessionsDirectory).exists({ superuser: "require" })
         .andThen((exists) => {
             if (exists)
             {
-                return this.server.execute(new Command(["find", sessionsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")]))
+                return this.server.execute(new Command(["find", sessionsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" }))
                 .map((proc) => proc.getStdout().split("\0").slice(0, -1))
                 .andThen((initiatorNames) => {
                     return ResultAsync.combine(initiatorNames.map((initiatorName) => {
@@ -296,8 +352,8 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
         
                             return ok<Session>({
                                 ...partialSession,
-                                readAmountKB:  StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/read_io_count_kb`])).safeUnwrap()).getStdout()).some(),
-                                writeAmountKB: StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/write_io_count_kb`])).safeUnwrap()).getStdout()).some(),
+                                readAmountKB:  StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/read_io_count_kb`], { superuser: "require" })).safeUnwrap()).getStdout()).some(),
+                                writeAmountKB: StringToIntCaster()((yield * self.server.execute(new Command(["cat", `${partialSession.devicePath}/write_io_count_kb`], { superuser: "require" })).safeUnwrap()).getStdout()).some(),
                                 connections: yield * self.getConnectionsOfSession(partialSession).safeUnwrap(),
                             });
                         }))
@@ -311,13 +367,13 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
     }
 
     getCHAPConfigurationsOfTarget(target: Pick<Target, "name">): ResultAsync<CHAPConfiguration[], ProcessError> {
-        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-type f ( -name IncomingUser* -o -name OutgoingUser* ) -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", this.getTargetPath(target), ..."-type f ( -name IncomingUser* -o -name OutgoingUser* ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => proc.getStdout().split("\0").slice(0, -1)
         ).andThen((configurationFileNames) => {
             return ResultAsync.combine(configurationFileNames.map((configurationFileName) => {
                 const file = new File(this.server, `${this.getTargetPath(target)}/${configurationFileName}`);
                 
-                return file.read().andThen((fileContent) => {
+                return file.read({ superuser: "require" }).andThen((fileContent) => {
                     const credentialLine = fileContent.split('\n')[0]
 
                     if (credentialLine === undefined)
@@ -345,7 +401,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const ignoredNames = ["latency", "lun", "."];
 
-        return this.server.execute(new Command(["find", `${session.devicePath}/`, ..."-type d -mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", `${session.devicePath}/`, ..."-type d -mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const connectionFileNames = proc.getStdout().split("\0").slice(0, -1);
                 return connectionFileNames.filter(directoryName => 
@@ -365,8 +421,8 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
                     return ok<Connection>({
                         ...partialConnection,
-                        connectionID: yield * connectionIDFile.read().safeUnwrap(),
-                        ipAddress: yield * ipFile.read().safeUnwrap(),
+                        connectionID: yield * connectionIDFile.read({ superuser: "require" }).safeUnwrap(),
+                        ipAddress: yield * ipFile.read({ superuser: "require" }).safeUnwrap(),
                     });
                 }))
             }))
@@ -378,7 +434,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const lunsDirectory = `${initiatorGroup.devicePath}/luns`;
 
-        return this.server.execute(new Command(["find", lunsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", lunsDirectory, ..."-mindepth 1 -maxdepth 1 ( -type d -o -type l ) -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 return proc.getStdout().split("\0").slice(0, -1);
             }
@@ -389,7 +445,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
                         unitNumber: StringToIntCaster()(number).some(),
                     };
 
-                    const lunDeviceName = (yield * self.server.execute(new Command(["cat", `${lunsDirectory}/${partialLogicalUnitNumber.unitNumber}/device/prod_id`])).safeUnwrap()).getStdout();
+                    const lunDeviceName = (yield * self.server.execute(new Command(["cat", `${lunsDirectory}/${partialLogicalUnitNumber.unitNumber}/device/prod_id`], { superuser: "require" })).safeUnwrap()).getStdout();
                     const device = (yield * self.getVirtualDevices().safeUnwrap()).find((device) => device.deviceName === lunDeviceName);
 
                     return ok<LogicalUnitNumber>({
@@ -407,7 +463,7 @@ export class ISCSIDriverSingleServer implements ISCSIDriver {
 
         const initiatorDirectory = `${initiatorGroup.devicePath}/initiators`;
 
-        return this.server.execute(new Command(["find", initiatorDirectory, ..."-mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")])).map(
+        return this.server.execute(new Command(["find", initiatorDirectory, ..."-mindepth 1 -maxdepth 1 -printf %f\\0".split(" ")], { superuser: "require" })).map(
             (proc) => {
                 const initiatorNames = proc.getStdout().split("\0").slice(0, -1);
                 return initiatorNames.filter(name => !ignoredNames.includes(name));


### PR DESCRIPTION
**Summary**
Adds Cockpit [superuser](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) privilege escalation to all iSCSI/SCST operations so that non-root admin users can use the iSCSI tab without getting "Permission denied" errors.

**Problem**
When a non-root user with admin privileges accesses the iSCSI tab in Cockpit, all SCST sysfs reads and scstadmin commands fail because they require root access. This results in:

"Permission denied" errors when the iSCSI tab loads
"This program must run as root" when exporting/importing SCST config

**Changes**

- [App.vue](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — iscsiConfigured(): added [superuser: "try"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the /sys/kernel/scst_tgt existence check so the tab visibility probe works for non-root users
- [ISCSIDriverSingleServer.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [initialize()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): added [superuser: "try"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the SCST directory check; added [superuser: "require"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to all SCST sysfs read/write operations ([find](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), cat, echo > mgmt, [file.read()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
- [ISCSIDriverClusteredServer.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [initialize()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): added [superuser: "try"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the SCST directory check
- [ConfigurationManager.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added [superuser: "require"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to all scstadmin, cat, [file.create()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [file.write()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and systemctl enable scst commands

**How it works**
[superuser: "try"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — used for detection/probe operations (checking if SCST is installed). Elevates if possible, falls back gracefully if not.
[superuser: "require"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — used for all SCST mutations and reads. Requires the user to have "Administrative access" enable