### PR TITLE
Connected Clients: live Samba and NFS session view

### DIFF
--- a/file-sharing/src/App.vue
+++ b/file-sharing/src/App.vue
@@ -13,6 +13,7 @@ import {
 import { SambaTabMain } from "@/tabs/samba/ui";
 import ISCSITabMain from "@/tabs/iSCSI/ui/ISCSITabMain.vue";
 import { NFSTabMain } from "@/tabs/nfs/ui";
+import { ConnectedClientsTabMain } from "@/tabs/connected-clients/ui";
 import UserSettingsView from "@/common/ui/UserSettingsView.vue";
 import { ref, computed, watchEffect, type WatchStopHandle, onUnmounted, watch } from "vue";
 import { Cog8ToothIcon } from "@heroicons/vue/20/solid";
@@ -35,6 +36,7 @@ const showSambaTab = ref(true);
 const showNfsTab = ref(true);
 const showIscsiTab = ref(true);
 const showS3Tab = ref(true);
+const showConnectedClientsTab = ref(true);
 const sambaConfigured = (): ResultAsync<boolean, never> => {
   return getServer()
     .andThen((server) => server.execute(new BashCommand("command -v net")))
@@ -67,6 +69,21 @@ const s3Configured = (): ResultAsync<boolean, never> => {
     ),
     () => null
   ).orElse((_) => ok(false));
+};
+
+// Shown when either smbstatus is present OR the kernel NFSv4 clients dir
+// exists. Either signal means we have at least one source of live data.
+const connectedClientsConfigured = (): ResultAsync<boolean, never> => {
+  return getServer()
+    .andThen((server) =>
+      server.execute(
+        new BashCommand(
+          "command -v smbstatus >/dev/null 2>&1 || [ -d /proc/fs/nfsd/clients ]"
+        )
+      )
+    )
+    .map((_) => true)
+    .orElse((_) => ok(false));
 };
 
 let watchStopHandle: WatchStopHandle;
@@ -177,6 +194,21 @@ globalProcessingWrapPromise(useUserSettings(true)).then((userSettings) => {
           );
           break;
       }
+      switch (userSettings.connectedClients.tabVisibility) {
+        case "always":
+          showConnectedClientsTab.value = true;
+          break;
+        case "never":
+          showConnectedClientsTab.value = false;
+          break;
+        case "auto":
+          globalProcessingWrapPromise(
+            connectedClientsConfigured()
+              .map((value) => (showConnectedClientsTab.value = value))
+              .unwrapOr(null)
+          );
+          break;
+      }
     },
     { immediate: true }
   );
@@ -216,7 +248,15 @@ const visibleTabs = computed<HoustonAppTabEntry[]>(() => [
           component: S3ManagementMain,
         },
       ]
-    : [])
+    : []),
+  ...(showConnectedClientsTab.value
+    ? [
+        {
+          label: "Connected Clients",
+          component: ConnectedClientsTabMain,
+        },
+      ]
+    : []),
 ]);
 </script>
 

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -43,6 +43,14 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
     value: "never",
   },
 ];
+
+const refreshIntervalOptions: SelectMenuOption<number>[] = [
+  { label: _("5 seconds"), value: 5 },
+  { label: _("10 seconds"), value: 10 },
+  { label: _("15 seconds"), value: 15 },
+  { label: _("30 seconds"), value: 30 },
+  { label: _("60 seconds"), value: 60 },
+];
 </script>
 
 <template>
@@ -145,6 +153,25 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
         <SelectMenu
           v-model="tempUserSettings.s3.tabVisibility"
           :options="tabVisibilityOptions"
+        />
+      </InputLabelWrapper>
+      <div class="text-header">{{ _("Connected Clients") }}</div>
+      <InputLabelWrapper>
+        <template #label>
+          {{ _("Connected Clients Tab Visibility") }}
+        </template>
+        <SelectMenu
+          v-model="tempUserSettings.connectedClients.tabVisibility"
+          :options="tabVisibilityOptions"
+        />
+      </InputLabelWrapper>
+      <InputLabelWrapper>
+        <template #label>
+          {{ _("Auto-refresh interval") }}
+        </template>
+        <SelectMenu
+          v-model="tempUserSettings.connectedClients.refreshIntervalSeconds"
+          :options="refreshIntervalOptions"
         />
       </InputLabelWrapper>
     </div>

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -174,6 +174,12 @@ const refreshIntervalOptions: SelectMenuOption<number>[] = [
           :options="refreshIntervalOptions"
         />
       </InputLabelWrapper>
+      <ToggleSwitch v-model="tempUserSettings.connectedClients.notifyOnChange">
+        {{ _("Notify on connect/disconnect") }}
+        <template #description>
+          {{ _("Show a toast when a client connects or disconnects between polls. Latency is bounded by the auto-refresh interval.") }}
+        </template>
+      </ToggleSwitch>
     </div>
     <template #footer>
       <div class="button-group-row justify-end">

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -119,10 +119,11 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             tabVisibility:
               contents.connectedClients?.tabVisibility ||
               defaultSettings().connectedClients.tabVisibility,
+            // `??` not `||` here and below: 0 / false are valid user choices
+            // (even if not currently exposed in the UI), don't overwrite with default.
             refreshIntervalSeconds:
-              contents.connectedClients?.refreshIntervalSeconds ||
+              contents.connectedClients?.refreshIntervalSeconds ??
               defaultSettings().connectedClients.refreshIntervalSeconds,
-            // `??` not `||`: false is a valid user choice, don't overwrite with default.
             notifyOnChange:
               contents.connectedClients?.notifyOnChange ??
               defaultSettings().connectedClients.notifyOnChange,

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -28,6 +28,14 @@ export type UserSettings = {
     tabVisibility: TabVisibility;
   };
   /**
+   * Connected-clients tab settings
+   */
+  connectedClients: {
+    tabVisibility: TabVisibility;
+    /** Auto-refresh interval in seconds. */
+    refreshIntervalSeconds: number;
+  };
+  /**
    * iSCSI-specific settings
    */
   iscsi: {
@@ -62,6 +70,10 @@ const defaultSettings = (): UserSettings => ({
   },
   s3: {
     tabVisibility: "auto",
+  },
+  connectedClients: {
+    tabVisibility: "auto",
+    refreshIntervalSeconds: 30,
   },
   iscsi: {
     // confPath: "/etc/scst/cockpit-iscsi.conf",
@@ -99,6 +111,14 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
           },
           s3: {
             tabVisibility: contents.s3?.tabVisibility || defaultSettings().s3.tabVisibility,
+          },
+          connectedClients: {
+            tabVisibility:
+              contents.connectedClients?.tabVisibility ||
+              defaultSettings().connectedClients.tabVisibility,
+            refreshIntervalSeconds:
+              contents.connectedClients?.refreshIntervalSeconds ||
+              defaultSettings().connectedClients.refreshIntervalSeconds,
           },
           iscsi: {
             // confPath: contents.iscsi?.confPath || defaultSettings().iscsi.confPath,

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -34,6 +34,8 @@ export type UserSettings = {
     tabVisibility: TabVisibility;
     /** Auto-refresh interval in seconds. */
     refreshIntervalSeconds: number;
+    /** Whether to push toast notifications when clients connect or disconnect between polls. */
+    notifyOnChange: boolean;
   };
   /**
    * iSCSI-specific settings
@@ -73,7 +75,8 @@ const defaultSettings = (): UserSettings => ({
   },
   connectedClients: {
     tabVisibility: "auto",
-    refreshIntervalSeconds: 30,
+    refreshIntervalSeconds: 5,
+    notifyOnChange: true,
   },
   iscsi: {
     // confPath: "/etc/scst/cockpit-iscsi.conf",
@@ -119,6 +122,10 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             refreshIntervalSeconds:
               contents.connectedClients?.refreshIntervalSeconds ||
               defaultSettings().connectedClients.refreshIntervalSeconds,
+            // `??` not `||`: false is a valid user choice, don't overwrite with default.
+            notifyOnChange:
+              contents.connectedClients?.notifyOnChange ??
+              defaultSettings().connectedClients.notifyOnChange,
           },
           iscsi: {
             // confPath: contents.iscsi?.confPath || defaultSettings().iscsi.confPath,

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -1,0 +1,19 @@
+import { ProcessError, Server } from "@45drives/houston-common-lib";
+import { ResultAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba-clients";
+import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
+
+export class ConnectedClientsManager {
+  constructor(public server: Server) {}
+
+  getClients(): ResultAsync<ConnectedClient[], ProcessError> {
+    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)]).map(
+      ([samba, nfs]) => [...samba, ...nfs]
+    );
+  }
+
+  kickSamba(ip: string): ResultAsync<void, ProcessError> {
+    return kickSambaClient(this.server, ip);
+  }
+}

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -1,16 +1,28 @@
-import { ProcessError, Server } from "@45drives/houston-common-lib";
+import { ParsingError, ProcessError, Server } from "@45drives/houston-common-lib";
 import { ResultAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba-clients";
 import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
+import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
+
+export type GetClientsError = ProcessError | ParsingError;
 
 export class ConnectedClientsManager {
   constructor(public server: Server) {}
 
-  getClients(): ResultAsync<ConnectedClient[], ProcessError> {
-    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)]).map(
-      ([samba, nfs]) => [...samba, ...nfs]
-    );
+  getClients(): ResultAsync<ConnectedClient[], GetClientsError> {
+    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)])
+      .map(([samba, nfs]) => [...samba, ...nfs])
+      .andThen((clients) =>
+        resolveHostnames(this.server, clients.map((c) => c.ip)).map((map) =>
+          clients.map((c) => ({
+            // NFS already extracts the hostname from the client `name`
+            // field — only fall back to reverse DNS when we have nothing.
+            ...c,
+            hostname: c.hostname ?? map.get(c.ip) ?? null,
+          }))
+        )
+      );
   }
 
   kickSamba(ip: string): ResultAsync<void, ProcessError> {

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -5,7 +5,7 @@ import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba
 import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
 import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
 
-export type GetClientsError = ProcessError | ParsingError;
+type GetClientsError = ProcessError | ParsingError;
 
 /**
  * Collapses raw per-tcon rows (Samba) and per-client rows (NFS) into one row

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -7,12 +7,49 @@ import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
 
 export type GetClientsError = ProcessError | ParsingError;
 
+/**
+ * Collapses raw per-tcon rows (Samba) and per-client rows (NFS) into one row
+ * per logical client, keyed by (protocol, user, ip). A user authenticated to
+ * Samba from one IP typically has 2+ tcons (IPC$ plus each share); without
+ * this aggregation they'd appear as separate rows and a single kick would
+ * fan out into multiple connect/disconnect notifications.
+ */
+function aggregateByLogicalClient(rows: ConnectedClient[]): ConnectedClient[] {
+  const groups = new Map<string, ConnectedClient[]>();
+  for (const r of rows) {
+    const key = `${r.protocol}:${r.user ?? ""}:${r.ip}`;
+    const arr = groups.get(key);
+    if (arr) arr.push(r);
+    else groups.set(key, [r]);
+  }
+  const out: ConnectedClient[] = [];
+  for (const [key, members] of groups) {
+    const first = members[0]!;
+    const shares = [...new Set(members.map((m) => m.share).filter((s): s is string => !!s))];
+    const dates = members
+      .map((m) => m.connectedSince)
+      .filter((d): d is Date => d !== null);
+    out.push({
+      ...first,
+      id: key,
+      share: shares.length > 0 ? shares.join(", ") : null,
+      connectedSince:
+        dates.length > 0 ? new Date(Math.min(...dates.map((d) => d.getTime()))) : null,
+      openFiles: members.reduce((s, m) => s + m.openFiles, 0),
+      // Conservative: only "Yes" if every tcon negotiated encryption. A
+      // partial encryption state should NOT show "Yes" to the operator.
+      encrypted: members.every((m) => m.encrypted),
+    });
+  }
+  return out;
+}
+
 export class ConnectedClientsManager {
   constructor(public server: Server) {}
 
   getClients(): ResultAsync<ConnectedClient[], GetClientsError> {
     return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)])
-      .map(([samba, nfs]) => [...samba, ...nfs])
+      .map(([samba, nfs]) => aggregateByLogicalClient([...samba, ...nfs]))
       .andThen((clients) =>
         resolveHostnames(this.server, clients.map((c) => c.ip)).map((map) =>
           clients.map((c) => ({

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -1,0 +1,19 @@
+export type ClientProtocol = "samba" | "nfs";
+
+export interface ConnectedClient {
+  /** Stable per-row key (e.g. `${protocol}:${sessionId}/${tconId}` or `nfs:${clientId}`) */
+  id: string;
+  protocol: ClientProtocol;
+  /** Authenticated username, when the protocol exposes one (Samba only today). */
+  user: string | null;
+  ip: string;
+  hostname: string | null;
+  /** e.g. "SMB3_11", "NFSv4.2". */
+  protocolVersion: string;
+  /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
+  share: string | null;
+  /** When the session/tcon was established. NFS clients have no exposed timestamp. */
+  connectedSince: Date | null;
+  openFiles: number;
+  encrypted: boolean;
+}

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -10,7 +10,13 @@ export interface ConnectedClient {
   hostname: string | null;
   /** e.g. "SMB3_11", "NFSv4.2". */
   protocolVersion: string;
-  /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
+  /**
+   * Samba: share name per tcon. NFS: comma-joined list of exports the client
+   * is *actively using* (derived by mapping each open file's superblock back
+   * to a mount path and then to an /etc/exports entry). NFSv4 has no per-
+   * client mount list at the server, so an idle-but-mounted NFS client shows
+   * null here. The UI surfaces this caveat via a hover tooltip.
+   */
   share: string | null;
   /**
    * When the session/tcon was established. Samba surfaces this directly per

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -12,7 +12,14 @@ export interface ConnectedClient {
   protocolVersion: string;
   /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
   share: string | null;
-  /** When the session/tcon was established. NFS clients have no exposed timestamp. */
+  /**
+   * When the session/tcon was established. Samba surfaces this directly per
+   * tcon; NFS has no dedicated "connected at" field (the kernel's only time
+   * value is `seconds from last renew`, which resets on every NFSv4 lease
+   * renewal), so we use the `/proc/fs/nfsd/clients/<id>/` dentry mtime as a
+   * proxy — it's set on first confirm and only changes on lease expiry +
+   * reconnect, which matches the operator's notion of "connected since".
+   */
   connectedSince: Date | null;
   openFiles: number;
   encrypted: boolean;

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
@@ -1,0 +1,115 @@
+import { BashCommand, ProcessError, Server } from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+
+const superuserOpts = { superuser: "try" as const };
+
+/**
+ * Reverse-resolves IPs to hostnames. Tries DNS first via NSS (`getent
+ * hosts`), then falls back to NetBIOS Node Status (`nmblookup -A`) for IPs
+ * DNS can't answer. NetBIOS catches Windows clients that have no PTR record
+ * but always respond to NBT name queries; Linux CIFS clients usually fail
+ * both and are left as null (UI shows "—").
+ *
+ * Returns whatever the resolver says verbatim — if DNS returns a short name
+ * (`quim`) that's what you'll get; if it returns an FQDN that's what you'll
+ * get; NetBIOS names are always returned in their registered short form.
+ */
+export function resolveHostnames(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  const unique = [...new Set(ips.filter((ip) => ip.length > 0))];
+  if (unique.length === 0) return okAsync(new Map());
+
+  return resolveViaDns(server, unique).andThen((dnsMap) => {
+    const unresolved = unique.filter((ip) => !dnsMap.get(ip));
+    if (unresolved.length === 0) return okAsync(dnsMap);
+    return resolveViaNetBIOS(server, unresolved).map((nbMap) => {
+      for (const [ip, name] of nbMap) if (name) dnsMap.set(ip, name);
+      return dnsMap;
+    });
+  });
+}
+
+function resolveViaDns(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  // getent hosts accepts multiple IPs in one call. `|| true` keeps the
+  // command zero-exit even when one or more IPs don't resolve.
+  const args = ips.map((_, i) => `"$${i + 1}"`).join(" ");
+  const script = `getent hosts ${args} 2>/dev/null || true`;
+
+  return server
+    .execute(new BashCommand(script, ips, superuserOpts))
+    .map((proc) => {
+      const out = new Map<string, string | null>();
+      for (const ip of ips) out.set(ip, null);
+      for (const line of proc.getStdout().split("\n")) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 2) continue;
+        const ip = parts[0];
+        const name = parts[1];
+        if (!ip || !name) continue;
+        out.set(ip, name);
+      }
+      return out;
+    })
+    .orElse(() => okAsync(new Map()));
+}
+
+/**
+ * NetBIOS Node Status query — asks each host directly for its registered
+ * names. The `<00>` record (without the `<GROUP>` tag) is the host's
+ * computer name. Silently skipped if nmblookup isn't installed.
+ */
+function resolveViaNetBIOS(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  const empty = () => {
+    const m = new Map<string, string | null>();
+    for (const ip of ips) m.set(ip, null);
+    return m;
+  };
+
+  // Loop in the shell so a non-responding host (nmblookup exit != 0) doesn't
+  // abort the batch. Frame each block so we can attribute output to its IP.
+  const script = `
+if ! command -v nmblookup >/dev/null 2>&1; then exit 0; fi
+for ip in "$@"; do
+  echo "---IP:$ip---"
+  nmblookup -A "$ip" 2>/dev/null || true
+done
+`.trim();
+
+  return server
+    .execute(new BashCommand(script, ips, superuserOpts))
+    .map((proc) => parseNmblookup(proc.getStdout(), ips))
+    .orElse(() => okAsync(empty()));
+}
+
+function parseNmblookup(stdout: string, ips: string[]): Map<string, string | null> {
+  const out = new Map<string, string | null>();
+  for (const ip of ips) out.set(ip, null);
+  if (!stdout.trim()) return out;
+
+  const blocks = stdout.split(/^---IP:([^-]+)---$/m);
+  // [pre, ip1, block1, ip2, block2, ...]
+  for (let i = 1; i < blocks.length; i += 2) {
+    const ip = blocks[i]?.trim();
+    const body = blocks[i + 1] ?? "";
+    if (!ip) continue;
+    // Look for a line like `\tQUIM            <00> -         B <ACTIVE>`.
+    // Skip <GROUP> entries (workgroup names) and the "Looking up status" header.
+    for (const raw of body.split("\n")) {
+      const line = raw.trim();
+      const m = line.match(/^(\S+)\s+<00>\s+-\s+(?!<GROUP>)/);
+      if (m && m[1]) {
+        out.set(ip, m[1]);
+        break;
+      }
+    }
+  }
+  return out;
+}

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
@@ -11,7 +11,7 @@ const superuserOpts = { superuser: "try" as const };
  * both and are left as null (UI shows "—").
  *
  * Returns whatever the resolver says verbatim — if DNS returns a short name
- * (`quim`) that's what you'll get; if it returns an FQDN that's what you'll
+ * (`nas01`) that's what you'll get; if it returns an FQDN that's what you'll
  * get; NetBIOS names are always returned in their registered short form.
  */
 export function resolveHostnames(
@@ -100,7 +100,7 @@ function parseNmblookup(stdout: string, ips: string[]): Map<string, string | nul
     const ip = blocks[i]?.trim();
     const body = blocks[i + 1] ?? "";
     if (!ip) continue;
-    // Look for a line like `\tQUIM            <00> -         B <ACTIVE>`.
+    // Look for a line like `\tWORKSTATION     <00> -         B <ACTIVE>`.
     // Skip <GROUP> entries (workgroup names) and the "Looking up status" header.
     for (const raw of body.split("\n")) {
       const line = raw.trim();

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -12,6 +12,11 @@ const superuserOpts = { superuser: "try" as const };
  * Bash payload that dumps every /proc/fs/nfsd/clients/<id>/{info,states} in a
  * single round-trip, framed by markers we parse below. We accept that this is
  * NFSv4-only: v3 clients have no kernel-side client identity.
+ *
+ * Requires the kernel's NFSv4 client tracking interface, available on Linux
+ * 5.3+. On older kernels (or hosts not running the NFS server) the directory
+ * is absent and this script exits cleanly with empty stdout — the UI then
+ * shows no NFS rows, which is the correct outcome.
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -28,6 +28,16 @@ const superuserOpts = { superuser: "try" as const };
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
+# Global context for share derivation (see deriveShares). Emitted once at the
+# top of the dump so it lives outside any CLIENT block. The MOUNTINFO maps a
+# superblock id (from the states file) back to a mount point; EXPORTS lists
+# the server's exported paths. Per-client states entries reference files by
+# (superblock, relative path) — joining these three lets us name the export(s)
+# a client is actively using.
+echo "---MOUNTINFO---"
+cat /proc/self/mountinfo 2>/dev/null
+echo "---EXPORTS---"
+cat /etc/exports /etc/exports.d/*.exports 2>/dev/null
 for d in /proc/fs/nfsd/clients/*/; do
   # When the directory exists but is empty, bash's default glob behavior keeps
   # the literal pattern, so $d would be ".../clients/*/" and basename would
@@ -107,12 +117,109 @@ function countStates(block: string): number {
     .filter((l) => l.length > 0).length;
 }
 
+/**
+ * Parse /proc/self/mountinfo into a map from "major:minor" (decimal, as
+ * mountinfo writes it) to the mount point path. We use the kernel's own
+ * device numbering as the join key for matching states-file entries below.
+ */
+function parseMountInfo(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const parts = raw.trim().split(/\s+/);
+    if (parts.length < 5) continue;
+    const majorMinor = parts[2];
+    const mountPath = parts[4];
+    if (majorMinor && mountPath && /^\d+:\d+$/.test(majorMinor)) {
+      map.set(majorMinor, mountPath);
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse one-or-more /etc/exports-style files into a set of exported paths.
+ * Skips comment and blank lines; first whitespace-delimited token on each
+ * remaining line is the export path. Wildcard / netgroup paths aren't
+ * supported by NFSv4 anyway, so a strict starts-with-"/" filter is enough.
+ */
+function parseExports(content: string): Set<string> {
+  const set = new Set<string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const path = line.split(/\s+/)[0];
+    if (path && path.startsWith("/")) set.add(path);
+  }
+  return set;
+}
+
+interface ParsedStateEntry {
+  filename: string;
+  /** "major:minor" in decimal, normalized to match parseMountInfo output. */
+  superblock: string;
+}
+
+/**
+ * Extract (filename, superblock) tuples from a client's states file. Each
+ * entry looks like:
+ *   - 0x<hex>: { type: open, ..., superblock: "00:4a:1260", filename: "foo/bar" }
+ * The superblock value is hex `major:minor:inode`; we drop the inode and
+ * convert major:minor to decimal so it joins against mountinfo's format.
+ */
+function parseStates(content: string): ParsedStateEntry[] {
+  const entries: ParsedStateEntry[] = [];
+  for (const line of content.split("\n")) {
+    const superMatch = line.match(/superblock:\s*"([0-9a-fA-F]+):([0-9a-fA-F]+):[0-9a-fA-F]+"/);
+    const fileMatch = line.match(/filename:\s*"([^"]*)"/);
+    if (!superMatch || !fileMatch) continue;
+    const majHex = superMatch[1];
+    const minHex = superMatch[2];
+    const filename = fileMatch[1];
+    if (!majHex || !minHex || filename === undefined) continue;
+    const decimal = `${parseInt(majHex, 16)}:${parseInt(minHex, 16)}`;
+    entries.push({ filename, superblock: decimal });
+  }
+  return entries;
+}
+
+/**
+ * Derive a comma-joined list of exports a client is *actively using*, by
+ * mapping each open file's superblock back to a mount path and then to a
+ * matching export. The Samba `Share` column reflects "mounted shares"
+ * because tcons are stateful per-share; NFSv4 has no such concept, so this
+ * column only populates while files are actively open. An idle-but-mounted
+ * client will show null here. The UI surfaces a tooltip to make this
+ * limitation discoverable.
+ */
+function deriveShares(
+  statesEntries: ParsedStateEntry[],
+  mountInfo: Map<string, string>,
+  exports: Set<string>
+): string | null {
+  if (statesEntries.length === 0 || exports.size === 0) return null;
+  const shares = new Set<string>();
+  for (const e of statesEntries) {
+    const mountPath = mountInfo.get(e.superblock);
+    if (mountPath && exports.has(mountPath)) shares.add(mountPath);
+  }
+  if (shares.size === 0) return null;
+  return [...shares].sort().join(", ");
+}
+
 function parseDump(stdout: string): ConnectedClient[] {
   const out: ConnectedClient[] = [];
   if (!stdout.trim()) return out;
 
   const clientBlocks = stdout.split(/^---CLIENT:([^-]+)---$/m);
-  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...]
+  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...].
+  // The "pre" slot (clientBlocks[0]) holds the global context (MOUNTINFO +
+  // EXPORTS) emitted before any client block.
+  const globalContext = clientBlocks[0] ?? "";
+  const mountInfoMatch = globalContext.match(/---MOUNTINFO---\n([\s\S]*?)(?=---EXPORTS---|$)/);
+  const exportsMatch = globalContext.match(/---EXPORTS---\n([\s\S]*?)$/);
+  const mountInfo = parseMountInfo(mountInfoMatch?.[1] ?? "");
+  const exports = parseExports(exportsMatch?.[1] ?? "");
+
   for (let i = 1; i < clientBlocks.length; i += 2) {
     const id = clientBlocks[i]?.trim();
     const body = clientBlocks[i + 1] ?? "";
@@ -123,8 +230,10 @@ function parseDump(stdout: string): ConnectedClient[] {
     const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
 
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
-    const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+    const statesContent = statesMatch?.[1] ?? "";
+    const openFiles = statesMatch ? countStates(statesContent) : 0;
     const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
+    const share = deriveShares(parseStates(statesContent), mountInfo, exports);
 
     // Defensive: skip blocks with no parseable address. The bash dump shouldn't
     // produce these (it filters non-directories), but a CLIENT marker with an
@@ -139,7 +248,7 @@ function parseDump(stdout: string): ConnectedClient[] {
       ip: parsed.address,
       hostname: parsed.hostname,
       protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
-      share: null,
+      share,
       connectedSince,
       openFiles,
       encrypted: false,

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -1,0 +1,121 @@
+import {
+  BashCommand,
+  ProcessError,
+  Server,
+} from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+
+const superuserOpts = { superuser: "try" as const };
+
+/**
+ * Bash payload that dumps every /proc/fs/nfsd/clients/<id>/{info,states} in a
+ * single round-trip, framed by markers we parse below. We accept that this is
+ * NFSv4-only: v3 clients have no kernel-side client identity.
+ */
+const dumpScript = `
+if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
+for d in /proc/fs/nfsd/clients/*/; do
+  id=$(basename "$d")
+  echo "---CLIENT:$id---"
+  if [ -r "$d/info" ]; then
+    echo "---INFO---"
+    cat "$d/info" 2>/dev/null
+  fi
+  if [ -r "$d/states" ]; then
+    echo "---STATES---"
+    cat "$d/states" 2>/dev/null
+  fi
+done
+`.trim();
+
+interface ParsedInfo {
+  address: string;
+  hostname: string | null;
+  minorVersion: string | null;
+  status: string | null;
+}
+
+function parseInfoBlock(block: string): ParsedInfo {
+  const info: Record<string, string> = {};
+  for (const raw of block.split("\n")) {
+    const line = raw.trim();
+    if (!line || !line.includes(":")) continue;
+    const idx = line.indexOf(":");
+    const k = line.slice(0, idx).trim();
+    const v = line.slice(idx + 1).trim();
+    info[k] = v;
+  }
+  // address looks like "192.168.1.10:919" or "[fe80::1]:919"
+  const rawAddr = info["address"] ?? "";
+  let address = rawAddr;
+  const ipv6 = rawAddr.match(/^\[([^\]]+)\]/);
+  if (ipv6) {
+    address = ipv6[1] ?? rawAddr;
+  } else if (rawAddr.includes(":")) {
+    address = rawAddr.split(":")[0] ?? rawAddr;
+  }
+  // name looks like "Linux NFSv4.2 hostname" — last whitespace-delimited token
+  // is usually the client hostname. Treat absence gracefully.
+  let hostname: string | null = null;
+  const name = info["name"];
+  if (name) {
+    const parts = name.split(/\s+/);
+    hostname = parts.length > 2 ? (parts[parts.length - 1] ?? null) : null;
+  }
+  return {
+    address,
+    hostname,
+    minorVersion: info["minor version"] ?? null,
+    status: info["status"] ?? null,
+  };
+}
+
+function countStates(block: string): number {
+  // The `states` file is one stateid per line (opens + locks + delegations).
+  // A rough "active opens" count is fine here; this is just a UI hint.
+  return block
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0).length;
+}
+
+function parseDump(stdout: string): ConnectedClient[] {
+  const out: ConnectedClient[] = [];
+  if (!stdout.trim()) return out;
+
+  const clientBlocks = stdout.split(/^---CLIENT:([^-]+)---$/m);
+  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...]
+  for (let i = 1; i < clientBlocks.length; i += 2) {
+    const id = clientBlocks[i]?.trim();
+    const body = clientBlocks[i + 1] ?? "";
+    if (!id) continue;
+
+    const infoMatch = body.match(/---INFO---\n([\s\S]*?)(?=---STATES---|$)/);
+    const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
+
+    const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
+    const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+
+    out.push({
+      id: `nfs:${id}`,
+      protocol: "nfs",
+      user: null,
+      ip: parsed.address,
+      hostname: parsed.hostname,
+      protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
+      share: null,
+      connectedSince: null,
+      openFiles,
+      encrypted: false,
+    });
+  }
+  return out;
+}
+
+export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  return server
+    .execute(new BashCommand(dumpScript, [], superuserOpts))
+    .map((proc) => parseDump(proc.getStdout()))
+    .orElse(() => okAsync([] as ConnectedClient[]));
+}

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -23,6 +23,11 @@ if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
 for d in /proc/fs/nfsd/clients/*/; do
   id=$(basename "$d")
   echo "---CLIENT:$id---"
+  # mtime of the client dentry = first-contact time. The kernel creates the
+  # dentry when a client confirms and only recreates it on lease expiry +
+  # reconnect, so this stays put across NFSv4 lease renewals.
+  echo "---MTIME---"
+  stat -c %Y "$d" 2>/dev/null
   if [ -r "$d/info" ]; then
     echo "---INFO---"
     cat "$d/info" 2>/dev/null
@@ -48,7 +53,12 @@ function parseInfoBlock(block: string): ParsedInfo {
     if (!line || !line.includes(":")) continue;
     const idx = line.indexOf(":");
     const k = line.slice(0, idx).trim();
-    const v = line.slice(idx + 1).trim();
+    let v = line.slice(idx + 1).trim();
+    // Recent kernels wrap values in double quotes (e.g. `address: "10.0.0.1:919"`,
+    // `name: "Linux NFSv4.2 host"`); older ones don't. Strip them defensively.
+    if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) {
+      v = v.slice(1, -1);
+    }
     info[k] = v;
   }
   // address looks like "192.168.1.10:919" or "[fe80::1]:919"
@@ -96,11 +106,13 @@ function parseDump(stdout: string): ConnectedClient[] {
     const body = clientBlocks[i + 1] ?? "";
     if (!id) continue;
 
+    const mtimeMatch = body.match(/---MTIME---\n([^\n]*)/);
     const infoMatch = body.match(/---INFO---\n([\s\S]*?)(?=---STATES---|$)/);
     const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
 
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
     const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+    const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
 
     out.push({
       id: `nfs:${id}`,
@@ -110,12 +122,18 @@ function parseDump(stdout: string): ConnectedClient[] {
       hostname: parsed.hostname,
       protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
       share: null,
-      connectedSince: null,
+      connectedSince,
       openFiles,
       encrypted: false,
     });
   }
   return out;
+}
+
+function parseMtime(s: string): Date | null {
+  const epoch = Number.parseInt(s.trim(), 10);
+  if (!Number.isFinite(epoch) || epoch <= 0) return null;
+  return new Date(epoch * 1000);
 }
 
 export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -3,7 +3,7 @@ import {
   ProcessError,
   Server,
 } from "@45drives/houston-common-lib";
-import { ResultAsync, okAsync } from "neverthrow";
+import { ResultAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 
 const superuserOpts = { superuser: "try" as const };
@@ -114,8 +114,10 @@ function parseDump(stdout: string): ConnectedClient[] {
 }
 
 export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  // The dump script itself handles "directory not present" (NFSv4 server not
+  // running) by exiting cleanly with empty stdout. Any other failure is real
+  // and should propagate so the UI can surface it.
   return server
     .execute(new BashCommand(dumpScript, [], superuserOpts))
-    .map((proc) => parseDump(proc.getStdout()))
-    .orElse(() => okAsync([] as ConnectedClient[]));
+    .map((proc) => parseDump(proc.getStdout()));
 }

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -119,18 +119,22 @@ function countStates(block: string): number {
 
 /**
  * Parse /proc/self/mountinfo into a map from "major:minor" (decimal, as
- * mountinfo writes it) to the mount point path. We use the kernel's own
- * device numbering as the join key for matching states-file entries below.
+ * mountinfo writes it) to the list of mount paths that share that device.
+ * Multi-value because a single filesystem can be mounted at multiple paths
+ * (e.g. ZFS dataset + bind mounts of it); we need to keep all candidates so
+ * deriveShares can pick the one that's actually an NFS export.
  */
-function parseMountInfo(content: string): Map<string, string> {
-  const map = new Map<string, string>();
+export function parseMountInfo(content: string): Map<string, string[]> {
+  const map = new Map<string, string[]>();
   for (const raw of content.split("\n")) {
     const parts = raw.trim().split(/\s+/);
     if (parts.length < 5) continue;
     const majorMinor = parts[2];
     const mountPath = parts[4];
     if (majorMinor && mountPath && /^\d+:\d+$/.test(majorMinor)) {
-      map.set(majorMinor, mountPath);
+      const existing = map.get(majorMinor);
+      if (existing) existing.push(mountPath);
+      else map.set(majorMinor, [mountPath]);
     }
   }
   return map;
@@ -142,7 +146,7 @@ function parseMountInfo(content: string): Map<string, string> {
  * remaining line is the export path. Wildcard / netgroup paths aren't
  * supported by NFSv4 anyway, so a strict starts-with-"/" filter is enough.
  */
-function parseExports(content: string): Set<string> {
+export function parseExports(content: string): Set<string> {
   const set = new Set<string>();
   for (const raw of content.split("\n")) {
     const line = raw.trim();
@@ -166,7 +170,7 @@ interface ParsedStateEntry {
  * The superblock value is hex `major:minor:inode`; we drop the inode and
  * convert major:minor to decimal so it joins against mountinfo's format.
  */
-function parseStates(content: string): ParsedStateEntry[] {
+export function parseStates(content: string): ParsedStateEntry[] {
   const entries: ParsedStateEntry[] = [];
   for (const line of content.split("\n")) {
     const superMatch = line.match(/superblock:\s*"([0-9a-fA-F]+):([0-9a-fA-F]+):[0-9a-fA-F]+"/);
@@ -191,22 +195,31 @@ function parseStates(content: string): ParsedStateEntry[] {
  * client will show null here. The UI surfaces a tooltip to make this
  * limitation discoverable.
  */
-function deriveShares(
+export function deriveShares(
   statesEntries: ParsedStateEntry[],
-  mountInfo: Map<string, string>,
+  mountInfo: Map<string, string[]>,
   exports: Set<string>
 ): string | null {
   if (statesEntries.length === 0 || exports.size === 0) return null;
   const shares = new Set<string>();
   for (const e of statesEntries) {
-    const mountPath = mountInfo.get(e.superblock);
-    if (mountPath && exports.has(mountPath)) shares.add(mountPath);
+    const candidates = mountInfo.get(e.superblock);
+    if (!candidates) continue;
+    // A single filesystem can have multiple mount paths (ZFS dataset + bind
+    // mounts, for example); find one that's actually exported. First match
+    // wins — they all reference the same underlying storage.
+    for (const path of candidates) {
+      if (exports.has(path)) {
+        shares.add(path);
+        break;
+      }
+    }
   }
   if (shares.size === 0) return null;
   return [...shares].sort().join(", ");
 }
 
-function parseDump(stdout: string): ConnectedClient[] {
+export function parseDump(stdout: string): ConnectedClient[] {
   const out: ConnectedClient[] = [];
   if (!stdout.trim()) return out;
 

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -17,10 +17,22 @@ const superuserOpts = { superuser: "try" as const };
  * 5.3+. On older kernels (or hosts not running the NFS server) the directory
  * is absent and this script exits cleanly with empty stdout — the UI then
  * shows no NFS rows, which is the correct outcome.
+ *
+ * NFSv4 lease semantics: the kernel only keeps a client entry while the
+ * client has an active lease (~90s since the last operation by default).
+ * An idle mount whose lease has lapsed will not appear here until the next
+ * I/O re-confirms it — any touch of the mount (`ls`, `stat`, file open)
+ * re-establishes the lease and the entry reappears. Operators should
+ * expect NFS rows to rotate in and out over time; that's the kernel's
+ * notion of "connected", not a bug in this view.
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
 for d in /proc/fs/nfsd/clients/*/; do
+  # When the directory exists but is empty, bash's default glob behavior keeps
+  # the literal pattern, so $d would be ".../clients/*/" and basename would
+  # give "*". Skip non-directories defensively (no nullglob assumption).
+  [ -d "$d" ] || continue
   id=$(basename "$d")
   echo "---CLIENT:$id---"
   # mtime of the client dentry = first-contact time. The kernel creates the
@@ -113,6 +125,12 @@ function parseDump(stdout: string): ConnectedClient[] {
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
     const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
     const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
+
+    // Defensive: skip blocks with no parseable address. The bash dump shouldn't
+    // produce these (it filters non-directories), but a CLIENT marker with an
+    // empty info block would otherwise render as a phantom row with id "nfs:*"
+    // and empty IP/hostname. Easier to guarantee correctness here too.
+    if (!parsed.address) continue;
 
     out.push({
       id: `nfs:${id}`,

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -55,6 +55,9 @@ function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
 }
 
 function parseDate(s: string | undefined): Date | null {
+  // Samba emits ISO 8601 with explicit TZ offset (e.g. "2025-04-15T15:32:46.123+00:00").
+  // new Date() parses that unambiguously; naive strings (no offset) would be interpreted
+  // as browser-local, silently producing wrong timestamps off by the browser-vs-server skew.
   if (!s) return null;
   const d = new Date(s);
   return Number.isNaN(d.getTime()) ? null : d;

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -1,9 +1,10 @@
 import {
   BashCommand,
+  ParsingError,
   ProcessError,
   Server,
 } from "@45drives/houston-common-lib";
-import { ResultAsync, okAsync } from "neverthrow";
+import { ResultAsync, err, ok, okAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 
 const superuserOpts = { superuser: "try" as const };
@@ -42,17 +43,9 @@ interface SmbStatusJson {
   open_files?: Record<string, SmbOpenFile>;
 }
 
-// `hostname` field looks like "ipv4:1.2.3.4:54321" or "ipv6:[::1]:1234"; pull
-// the printable address if we have it, else fall back to remote_machine.
-function parseHostname(session: SmbSession): string | null {
-  const h = session.hostname;
-  if (!h) return null;
-  const ipv4 = h.match(/^ipv4:([^:]+):\d+$/);
-  if (ipv4) return ipv4[1] ?? null;
-  const ipv6 = h.match(/^ipv6:\[([^\]]+)\]:\d+$/);
-  if (ipv6) return ipv6[1] ?? null;
-  return null;
-}
+// smbstatus -j's `hostname` field is just the connection endpoint string
+// (e.g. "ipv4:1.2.3.4:54321") — not a real DNS name. Samba doesn't surface a
+// resolved hostname here, so leave it null and let the UI show "—".
 
 function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
   if (!enc) return false;
@@ -92,7 +85,7 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
       protocol: "samba",
       user: session.username ?? null,
       ip: session.remote_machine ?? tcon.machine ?? "",
-      hostname: parseHostname(session),
+      hostname: null,
       protocolVersion: session.session_dialect ?? "SMB",
       share: tcon.service ?? null,
       connectedSince: parseDate(tcon.connected_at) ?? parseDate(session.auth_time),
@@ -112,7 +105,7 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
       protocol: "samba",
       user: session.username ?? null,
       ip: session.remote_machine ?? "",
-      hostname: parseHostname(session),
+      hostname: null,
       protocolVersion: session.session_dialect ?? "SMB",
       share: null,
       connectedSince: parseDate(session.auth_time),
@@ -124,7 +117,9 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
   return rows;
 }
 
-export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+export function getSambaClients(
+  server: Server
+): ResultAsync<ConnectedClient[], ProcessError | ParsingError> {
   // Empty list if smbstatus is unavailable — keeps the tab functional on NFS-only boxes.
   return server
     .execute(new BashCommand("command -v smbstatus >/dev/null 2>&1"), false)
@@ -132,14 +127,15 @@ export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], 
       if (!proc.succeeded()) return okAsync([] as ConnectedClient[]);
       return server
         .execute(new BashCommand("smbstatus -j 2>/dev/null", [], superuserOpts))
-        .map((p) => {
+        .andThen((p) => {
           const out = p.getStdout().trim();
-          if (!out) return [] as ConnectedClient[];
+          if (!out) return ok([] as ConnectedClient[]);
           try {
             const parsed = JSON.parse(out) as SmbStatusJson;
-            return buildClients(parsed);
-          } catch {
-            return [] as ConnectedClient[];
+            return ok(buildClients(parsed));
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            return err(new ParsingError(`smbstatus -j returned invalid JSON: ${msg}`));
           }
         });
     });

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -1,0 +1,157 @@
+import {
+  BashCommand,
+  ProcessError,
+  Server,
+} from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+
+const superuserOpts = { superuser: "try" as const };
+
+interface SmbStatusEncryption {
+  cipher?: string;
+  degree?: string;
+}
+
+interface SmbSession {
+  session_id?: string;
+  username?: string;
+  remote_machine?: string;
+  hostname?: string;
+  session_dialect?: string;
+  auth_time?: string;
+  encryption?: SmbStatusEncryption;
+}
+
+interface SmbTcon {
+  tcon_id?: string;
+  session_id?: string;
+  service?: string;
+  machine?: string;
+  connected_at?: string;
+  encryption?: SmbStatusEncryption;
+}
+
+interface SmbOpenFile {
+  opens?: Record<string, unknown>;
+}
+
+interface SmbStatusJson {
+  sessions?: Record<string, SmbSession>;
+  tcons?: Record<string, SmbTcon>;
+  open_files?: Record<string, SmbOpenFile>;
+}
+
+// `hostname` field looks like "ipv4:1.2.3.4:54321" or "ipv6:[::1]:1234"; pull
+// the printable address if we have it, else fall back to remote_machine.
+function parseHostname(session: SmbSession): string | null {
+  const h = session.hostname;
+  if (!h) return null;
+  const ipv4 = h.match(/^ipv4:([^:]+):\d+$/);
+  if (ipv4) return ipv4[1] ?? null;
+  const ipv6 = h.match(/^ipv6:\[([^\]]+)\]:\d+$/);
+  if (ipv6) return ipv6[1] ?? null;
+  return null;
+}
+
+function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
+  if (!enc) return false;
+  const cipher = (enc.cipher ?? "").trim();
+  const degree = (enc.degree ?? "").trim().toLowerCase();
+  return cipher !== "" && cipher !== "-" && degree !== "none" && degree !== "";
+}
+
+function parseDate(s: string | undefined): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function buildClients(status: SmbStatusJson): ConnectedClient[] {
+  const sessions = status.sessions ?? {};
+  const tcons = status.tcons ?? {};
+  const openFiles = status.open_files ?? {};
+
+  // Pre-compute per-(session,tcon) open-file counts.
+  const openCounts = new Map<string, number>();
+  for (const file of Object.values(openFiles)) {
+    for (const key of Object.keys(file.opens ?? {})) {
+      openCounts.set(key, (openCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const rows: ConnectedClient[] = [];
+  for (const tcon of Object.values(tcons)) {
+    const sessionId = tcon.session_id ?? "";
+    const session = sessions[sessionId] ?? {};
+    const tconId = tcon.tcon_id ?? "";
+    const key = `${sessionId}/${tconId}`;
+
+    rows.push({
+      id: `samba:${key}`,
+      protocol: "samba",
+      user: session.username ?? null,
+      ip: session.remote_machine ?? tcon.machine ?? "",
+      hostname: parseHostname(session),
+      protocolVersion: session.session_dialect ?? "SMB",
+      share: tcon.service ?? null,
+      connectedSince: parseDate(tcon.connected_at) ?? parseDate(session.auth_time),
+      openFiles: openCounts.get(key) ?? 0,
+      encrypted: isEncrypted(tcon.encryption) || isEncrypted(session.encryption),
+    });
+  }
+
+  // Sessions without a tcon (rare but possible during connect) — surface them too.
+  const tconnedSessions = new Set(
+    Object.values(tcons).map((t) => t.session_id ?? "")
+  );
+  for (const [sid, session] of Object.entries(sessions)) {
+    if (tconnedSessions.has(sid)) continue;
+    rows.push({
+      id: `samba:${sid}/-`,
+      protocol: "samba",
+      user: session.username ?? null,
+      ip: session.remote_machine ?? "",
+      hostname: parseHostname(session),
+      protocolVersion: session.session_dialect ?? "SMB",
+      share: null,
+      connectedSince: parseDate(session.auth_time),
+      openFiles: 0,
+      encrypted: isEncrypted(session.encryption),
+    });
+  }
+
+  return rows;
+}
+
+export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  // Empty list if smbstatus is unavailable — keeps the tab functional on NFS-only boxes.
+  return server
+    .execute(new BashCommand("command -v smbstatus >/dev/null 2>&1"), false)
+    .andThen((proc) => {
+      if (!proc.succeeded()) return okAsync([] as ConnectedClient[]);
+      return server
+        .execute(new BashCommand("smbstatus -j 2>/dev/null", [], superuserOpts))
+        .map((p) => {
+          const out = p.getStdout().trim();
+          if (!out) return [] as ConnectedClient[];
+          try {
+            const parsed = JSON.parse(out) as SmbStatusJson;
+            return buildClients(parsed);
+          } catch {
+            return [] as ConnectedClient[];
+          }
+        });
+    });
+}
+
+export function kickSambaClient(server: Server, ip: string): ResultAsync<void, ProcessError> {
+  // smbcontrol takes an IP and disconnects every session from that client.
+  // Pass the IP via argv so shell metacharacters in user input can't be abused.
+  const safeIp = ip.replace(/[^0-9a-fA-F:.]/g, "");
+  return server
+    .execute(
+      new BashCommand(`smbcontrol smbd kill-client-ip "$1"`, [safeIp], superuserOpts)
+    )
+    .map(() => undefined);
+}

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -28,26 +28,70 @@ const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   []
 );
 
-// Diff successive polls to fire connect/disconnect toasts. Rows are
-// aggregated by logical client (protocol + user + IP) in the manager, so
-// client.id IS the logical-client key here — no further grouping needed.
-// `null` baseline = no diff yet (first load just records, never notifies);
-// baseline updates regardless of notifyOnChange so toggling that setting
-// on doesn't backfire stale events.
+// Diff successive polls to fire toasts covering five kinds of events:
+//  - Client connected: first time we see this logical client
+//  - Client disconnected: logical client gone
+//  - Client reconnected: same logical client, new session (different
+//    connectedSince) — typical kick → auto-reconnect case
+//  - Share connected: same logical client, same session, share appeared
+//  - Share disconnected: same logical client, same session, share dropped
+//
+// Rows are aggregated by logical client (protocol + user + IP) in the
+// manager, so client.id IS the logical-client key. `null` baseline = no
+// diff yet (first load just records, never notifies); baseline updates
+// regardless of notifyOnChange so toggling that setting on doesn't
+// backfire stale events.
 const previousByID = ref<Map<string, ConnectedClient> | null>(null);
-const clientLabel = (c: ConnectedClient): string => {
+const clientIdentity = (c: ConnectedClient): string => {
   const who = c.hostname ?? c.ip;
   return c.user ? `${c.user}@${who}` : who;
+};
+const clientLabel = (c: ConnectedClient): string => {
+  const id = clientIdentity(c);
+  return c.share ? `${id} · ${c.share}` : id;
+};
+const shareLabel = (c: ConnectedClient, share: string): string =>
+  `${share} · ${clientIdentity(c)}`;
+const shareSet = (s: string | null): Set<string> =>
+  new Set(s ? s.split(", ") : []);
+const sessionDiffers = (a: Date | null, b: Date | null): boolean => {
+  if (a === null && b === null) return false;
+  if (a === null || b === null) return true;
+  return a.getTime() !== b.getTime();
 };
 watch(clients, (newClients) => {
   const newMap = new Map(newClients.map((c) => [c.id, c]));
   const prev = previousByID.value;
   if (prev !== null && userSettings.value.connectedClients.notifyOnChange) {
     for (const c of newClients) {
-      if (!prev.has(c.id)) {
+      const old = prev.get(c.id);
+      if (!old) {
         pushNotification(
           new Notification(_("Client connected"), clientLabel(c), "info")
         );
+      } else if (sessionDiffers(c.connectedSince, old.connectedSince)) {
+        pushNotification(
+          new Notification(_("Client reconnected"), clientLabel(c), "info")
+        );
+      } else {
+        // Same id, same session — check for share-set delta. A user can
+        // mount additional shares or drop some while keeping their session.
+        const oldShares = shareSet(old.share);
+        const newShares = shareSet(c.share);
+        for (const s of newShares) {
+          if (!oldShares.has(s)) {
+            pushNotification(
+              new Notification(_("Share connected"), shareLabel(c, s), "info")
+            );
+          }
+        }
+        for (const s of oldShares) {
+          if (!newShares.has(s)) {
+            pushNotification(
+              new Notification(_("Share disconnected"), shareLabel(c, s), "info")
+            );
+          }
+        }
       }
     }
     for (const [id, c] of prev) {

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -122,7 +122,7 @@ const fallback = (v: string | null | undefined): string =>
         <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
           <Table
             noScroll
-            emptyText="No connected clients."
+            :emptyText='_("No connected clients.")'
             class="!border-none !shadow-none"
           >
             <template #thead>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -56,7 +56,9 @@ const startTimer = () => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
   const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
   refreshTimer = window.setInterval(() => {
-    actions.reloadClients();
+    // Background polling: silence errors so a chronic failure doesn't spam
+    // notifications every tick. Manual refresh (below) still surfaces them.
+    reloadClients().mapErr(() => undefined);
   }, ms);
 };
 
@@ -66,19 +68,21 @@ onUnmounted(() => {
 });
 watch(refreshIntervalSeconds, startTimer);
 
-const kickClient = (client: ConnectedClient) =>
-  assertConfirm({
+const kickClient = (client: ConnectedClient) => {
+  const label = client.hostname ? `${client.hostname} (${client.ip})` : client.ip;
+  return assertConfirm({
     header: _("Disconnect Samba client?"),
     body:
-      _("This drops all sessions from") +
-      ` ${client.ip}` +
-      ` (smbcontrol smbd kill-client-ip).`,
+      _("All open sessions and file handles from") +
+      ` ${label} ` +
+      _("will be closed. The client may reconnect automatically."),
     dangerous: true,
   })
     .andThen(() => manager)
     .andThen((m) => m.kickSamba(client.ip))
     .andThen(() => reloadClients())
-    .map(() => reportSuccess(_("Disconnected") + ` ${client.ip}`));
+    .map(() => reportSuccess(_("Disconnected") + ` ${label}`));
+};
 
 const actions = wrapActions({
   reloadClients,
@@ -97,11 +101,7 @@ const fallback = (v: string | null | undefined): string =>
         <div class="flex items-center justify-between gap-3 flex-wrap">
           <span>{{ _("Connected Clients") }}</span>
           <div class="flex items-center gap-2">
-            <SelectMenu
-              v-model="filter"
-              :options="filterOptions"
-              class="min-w-[8rem]"
-            />
+            <SelectMenu v-model="filter" :options="filterOptions" />
             <button
               class="btn btn-secondary inline-flex flex-row items-center gap-1"
               @click="actions.reloadClients()"
@@ -117,7 +117,6 @@ const fallback = (v: string | null | undefined): string =>
         <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
           <Table
             emptyText="No connected clients."
-            noScroll
             class="!border-none !shadow-none"
           >
             <template #thead>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -2,16 +2,19 @@
 import {
   CardContainer,
   CenteredCardColumn,
+  Notification,
   SelectMenu,
   Table,
   assertConfirm,
   computedResult,
+  pushNotification,
   reportSuccess,
   wrapActions,
   type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
 import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
@@ -30,16 +33,42 @@ const manager = server.map((s) => new ConnectedClientsManager(s));
 
 type Filter = "all" | ClientProtocol;
 const filter = ref<Filter>("all");
-const filterOptions: SelectMenuOption<Filter>[] = [
-  { label: _("All"), value: "all" },
-  { label: _("Samba"), value: "samba" },
-  { label: _("NFS"), value: "nfs" },
-];
 
 const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   () => manager.andThen((m) => m.getClients()),
   []
 );
+
+// Track previously-seen clients (full record, so we can label dropped rows
+// after they're gone). `null` baseline = no diff yet (first load just records,
+// never notifies). The baseline updates regardless of notifyOnChange so
+// toggling that setting on doesn't backfire stale events.
+const previousByID = ref<Map<string, ConnectedClient> | null>(null);
+const clientLabel = (c: ConnectedClient): string => {
+  const who = c.hostname ?? c.ip;
+  return c.user ? `${c.user}@${who}` : who;
+};
+watch(clients, (newClients) => {
+  const newMap = new Map(newClients.map((c) => [c.id, c]));
+  const prev = previousByID.value;
+  if (prev !== null && userSettings.value.connectedClients.notifyOnChange) {
+    for (const c of newClients) {
+      if (!prev.has(c.id)) {
+        pushNotification(
+          new Notification(_("Client connected"), clientLabel(c), "info")
+        );
+      }
+    }
+    for (const [id, c] of prev) {
+      if (!newMap.has(id)) {
+        pushNotification(
+          new Notification(_("Client disconnected"), clientLabel(c), "warning")
+        );
+      }
+    }
+  }
+  previousByID.value = newMap;
+});
 
 const filteredClients = computed(() =>
   filter.value === "all"
@@ -47,19 +76,75 @@ const filteredClients = computed(() =>
     : clients.value.filter((c) => c.protocol === filter.value)
 );
 
+const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
+  const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
+  const nfsCount = clients.value.filter((c) => c.protocol === "nfs").length;
+  const total = clients.value.length;
+  return [
+    { label: `${_("All")} (${total})`, value: "all" },
+    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
+    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
+  ];
+});
+
 const refreshIntervalSeconds = computed(
   () => userSettings.value.connectedClients.refreshIntervalSeconds
 );
+
+// `inFlight` gates concurrent fetches AND drives the spinner animation on
+// the refresh icon. Two reasons for the single source of truth:
+//  1) Skip-overlap: if a poll is still running when the next tick (or a
+//     manual click) fires, the new one no-ops. Cancelling + restarting
+//     hung calls (DNS timeout, slow nmblookup) just produces a fresh
+//     hang — and Cockpit lacks first-class cancellation primitives.
+//  2) Min-spin duration: local fetches usually finish in <100ms, so the
+//     animate-spin barely registers visually. Holding inFlight true for
+//     at least MIN_SPIN_MS lets the user perceive each refresh tick.
+const inFlight = ref(false);
+const MIN_SPIN_MS = 400;
+let spinStartedAt = 0;
+const beginInFlight = () => {
+  inFlight.value = true;
+  spinStartedAt = performance.now();
+};
+const releaseInFlight = () => {
+  const remaining = MIN_SPIN_MS - (performance.now() - spinStartedAt);
+  if (remaining <= 0) {
+    inFlight.value = false;
+  } else {
+    window.setTimeout(() => {
+      inFlight.value = false;
+    }, remaining);
+  }
+};
+
+// Background poll: silence errors so a chronic failure doesn't spam
+// notifications every tick. ResultAsync is PromiseLike, not Promise, so
+// we use .then(success, error) instead of .finally for cleanup.
+const pollTick = () => {
+  if (inFlight.value) return;
+  beginInFlight();
+  reloadClients()
+    .mapErr(() => undefined)
+    .then(releaseInFlight, releaseInFlight);
+};
+
+// Manual refresh: surfaces errors via wrapActions's notification handler.
+// If a poll is already in flight, return an immediately-resolved ok so
+// the click silently no-ops.
+const refreshNow = () => {
+  if (inFlight.value) return okAsync(undefined as void);
+  beginInFlight();
+  const r = reloadClients();
+  r.then(releaseInFlight, releaseInFlight);
+  return r;
+};
 
 let refreshTimer: number | undefined;
 const startTimer = () => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
   const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
-  refreshTimer = window.setInterval(() => {
-    // Background polling: silence errors so a chronic failure doesn't spam
-    // notifications every tick. Manual refresh (below) still surfaces them.
-    reloadClients().mapErr(() => undefined);
-  }, ms);
+  refreshTimer = window.setInterval(pollTick, ms);
 };
 
 onMounted(startTimer);
@@ -85,7 +170,7 @@ const kickClient = (client: ConnectedClient) => {
 };
 
 const actions = wrapActions({
-  reloadClients,
+  refreshNow,
   kickClient,
 });
 
@@ -104,10 +189,13 @@ const fallback = (v: string | null | undefined): string =>
             <SelectMenu v-model="filter" :options="filterOptions" />
             <button
               class="btn btn-secondary inline-flex flex-row items-center gap-1"
-              @click="actions.reloadClients()"
+              @click="actions.refreshNow()"
               :title="_('Refresh now')"
             >
-              <ArrowPathIcon class="size-icon icon-default" />
+              <ArrowPathIcon
+                class="size-icon icon-default"
+                :class="{ 'animate-spin': inFlight }"
+              />
               <span>{{ _("Refresh") }}</span>
             </button>
           </div>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -114,8 +114,14 @@ const fallback = (v: string | null | undefined): string =>
         </div>
       </template>
       <div class="card">
-        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
+        <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
+             Table's default scroll wrapper leaks the table's natural width up to
+             <html>, which combined with SelectMenu's scrollIntoView() causes the
+             page to scroll horizontally when the dropdown opens. Keeping the
+             scroll container at this level (and isolating layout) avoids it. -->
+        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
           <Table
+            noScroll
             emptyText="No connected clients."
             class="!border-none !shadow-none"
           >

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -13,7 +13,11 @@ import {
   type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/vue/20/solid";
 import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
@@ -39,10 +43,12 @@ const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   []
 );
 
-// Track previously-seen clients (full record, so we can label dropped rows
-// after they're gone). `null` baseline = no diff yet (first load just records,
-// never notifies). The baseline updates regardless of notifyOnChange so
-// toggling that setting on doesn't backfire stale events.
+// Diff successive polls to fire connect/disconnect toasts. Rows are
+// aggregated by logical client (protocol + user + IP) in the manager, so
+// client.id IS the logical-client key here — no further grouping needed.
+// `null` baseline = no diff yet (first load just records, never notifies);
+// baseline updates regardless of notifyOnChange so toggling that setting
+// on doesn't backfire stale events.
 const previousByID = ref<Map<string, ConnectedClient> | null>(null);
 const clientLabel = (c: ConnectedClient): string => {
   const who = c.hostname ?? c.ip;
@@ -75,6 +81,70 @@ const filteredClients = computed(() =>
     ? clients.value
     : clients.value.filter((c) => c.protocol === filter.value)
 );
+
+type SortField =
+  | "protocol"
+  | "user"
+  | "ip"
+  | "protocolVersion"
+  | "share"
+  | "connectedSince"
+  | "openFiles"
+  | "encrypted";
+type SortDir = "asc" | "desc";
+
+// `null` = unsorted (rows in arrival order from the manager). Clicking a
+// column cycles asc → desc → unsorted → asc, so users can clear a sort
+// without picking a different column.
+const sortBy = ref<SortField | null>("ip");
+const sortDir = ref<SortDir>("asc");
+
+const toggleSort = (field: SortField) => {
+  if (sortBy.value === field) {
+    if (sortDir.value === "asc") {
+      sortDir.value = "desc";
+    } else {
+      sortBy.value = null;
+    }
+  } else {
+    sortBy.value = field;
+    sortDir.value = "asc";
+  }
+};
+
+const sortValue = (c: ConnectedClient, f: SortField): string | number => {
+  switch (f) {
+    case "protocol":
+      return c.protocol;
+    case "user":
+      return c.user ?? "";
+    case "ip":
+      return c.ip;
+    case "protocolVersion":
+      return c.protocolVersion;
+    case "share":
+      return c.share ?? "";
+    case "connectedSince":
+      return c.connectedSince ? c.connectedSince.getTime() : 0;
+    case "openFiles":
+      return c.openFiles;
+    case "encrypted":
+      return c.encrypted ? 1 : 0;
+  }
+};
+
+const sortedClients = computed(() => {
+  const f = sortBy.value;
+  if (f === null) return filteredClients.value;
+  const arr = [...filteredClients.value];
+  const dir = sortDir.value === "asc" ? 1 : -1;
+  return arr.sort((a, b) => {
+    const av = sortValue(a, f);
+    const bv = sortValue(b, f);
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    return String(av).localeCompare(String(bv)) * dir;
+  });
+});
 
 const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
   const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
@@ -215,19 +285,67 @@ const fallback = (v: string | null | undefined): string =>
           >
             <template #thead>
               <tr>
-                <th scope="col">{{ _("Protocol") }}</th>
-                <th scope="col">{{ _("User") }}</th>
-                <th scope="col">{{ _("Client") }}</th>
-                <th scope="col">{{ _("Version") }}</th>
-                <th scope="col">{{ _("Share") }}</th>
-                <th scope="col">{{ _("Connected since") }}</th>
-                <th scope="col">{{ _("Open files") }}</th>
-                <th scope="col">{{ _("Encrypted") }}</th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
+                    {{ _("Protocol") }}
+                    <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
+                    {{ _("User") }}
+                    <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
+                    {{ _("Client") }}
+                    <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
+                    {{ _("Version") }}
+                    <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
+                    {{ _("Share") }}
+                    <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
+                    {{ _("Connected since") }}
+                    <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
+                    {{ _("Open files") }}
+                    <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
+                    {{ _("Encrypted") }}
+                    <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
                 <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
               </tr>
             </template>
             <template #tbody>
-              <tr v-for="client in filteredClients" :key="client.id">
+              <tr v-for="client in sortedClients" :key="client.id">
                 <td>
                   <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
                 </td>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -112,6 +112,15 @@ const toggleSort = (field: SortField) => {
   }
 };
 
+// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
+// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
+// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
+const ipSortKey = (ip: string): string => {
+  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return ip;
+  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
+};
+
 const sortValue = (c: ConnectedClient, f: SortField): string | number => {
   switch (f) {
     case "protocol":
@@ -119,7 +128,7 @@ const sortValue = (c: ConnectedClient, f: SortField): string | number => {
     case "user":
       return c.user ?? "";
     case "ip":
-      return c.ip;
+      return ipSortKey(c.ip);
     case "protocolVersion":
       return c.protocolVersion;
     case "share":

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -1,42 +1,27 @@
 <script setup lang="ts">
 import {
-  CardContainer,
   CenteredCardColumn,
   Notification,
-  SelectMenu,
-  Table,
   assertConfirm,
   computedResult,
   pushNotification,
   reportSuccess,
   wrapActions,
-  type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
-import {
-  ArrowPathIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from "@heroicons/vue/20/solid";
 import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
-import type {
-  ClientProtocol,
-  ConnectedClient,
-} from "@/tabs/connected-clients/data-types";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+import ConnectedClientsTableView from "@/tabs/connected-clients/ui/ConnectedClientsTableView.vue";
 import { useUserSettings } from "@/common/user-settings";
 
 const _ = cockpit.gettext;
 
 const userSettings = useUserSettings();
-
 const server = getServer();
 const manager = server.map((s) => new ConnectedClientsManager(s));
-
-type Filter = "all" | ClientProtocol;
-const filter = ref<Filter>("all");
 
 const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   () => manager.andThen((m) => m.getClients()),
@@ -74,96 +59,6 @@ watch(clients, (newClients) => {
     }
   }
   previousByID.value = newMap;
-});
-
-const filteredClients = computed(() =>
-  filter.value === "all"
-    ? clients.value
-    : clients.value.filter((c) => c.protocol === filter.value)
-);
-
-type SortField =
-  | "protocol"
-  | "user"
-  | "ip"
-  | "protocolVersion"
-  | "share"
-  | "connectedSince"
-  | "openFiles"
-  | "encrypted";
-type SortDir = "asc" | "desc";
-
-// `null` = unsorted (rows in arrival order from the manager). Clicking a
-// column cycles asc → desc → unsorted → asc, so users can clear a sort
-// without picking a different column.
-const sortBy = ref<SortField | null>("ip");
-const sortDir = ref<SortDir>("asc");
-
-const toggleSort = (field: SortField) => {
-  if (sortBy.value === field) {
-    if (sortDir.value === "asc") {
-      sortDir.value = "desc";
-    } else {
-      sortBy.value = null;
-    }
-  } else {
-    sortBy.value = field;
-    sortDir.value = "asc";
-  }
-};
-
-// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
-// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
-// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
-const ipSortKey = (ip: string): string => {
-  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-  if (!m) return ip;
-  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
-};
-
-const sortValue = (c: ConnectedClient, f: SortField): string | number => {
-  switch (f) {
-    case "protocol":
-      return c.protocol;
-    case "user":
-      return c.user ?? "";
-    case "ip":
-      return ipSortKey(c.ip);
-    case "protocolVersion":
-      return c.protocolVersion;
-    case "share":
-      return c.share ?? "";
-    case "connectedSince":
-      return c.connectedSince ? c.connectedSince.getTime() : 0;
-    case "openFiles":
-      return c.openFiles;
-    case "encrypted":
-      return c.encrypted ? 1 : 0;
-  }
-};
-
-const sortedClients = computed(() => {
-  const f = sortBy.value;
-  if (f === null) return filteredClients.value;
-  const arr = [...filteredClients.value];
-  const dir = sortDir.value === "asc" ? 1 : -1;
-  return arr.sort((a, b) => {
-    const av = sortValue(a, f);
-    const bv = sortValue(b, f);
-    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
-    return String(av).localeCompare(String(bv)) * dir;
-  });
-});
-
-const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
-  const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
-  const nfsCount = clients.value.filter((c) => c.protocol === "nfs").length;
-  const total = clients.value.length;
-  return [
-    { label: `${_("All")} (${total})`, value: "all" },
-    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
-    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
-  ];
 });
 
 const refreshIntervalSeconds = computed(
@@ -252,140 +147,15 @@ const actions = wrapActions({
   refreshNow,
   kickClient,
 });
-
-const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
-const fallback = (v: string | null | undefined): string =>
-  v && v.length > 0 ? v : "—";
 </script>
 
 <template>
   <CenteredCardColumn>
-    <CardContainer>
-      <template #header>
-        <div class="flex items-center justify-between gap-3 flex-wrap">
-          <span>{{ _("Connected Clients") }}</span>
-          <div class="flex items-center gap-2">
-            <SelectMenu v-model="filter" :options="filterOptions" />
-            <button
-              class="btn btn-secondary inline-flex flex-row items-center gap-1"
-              @click="actions.refreshNow()"
-              :title="_('Refresh now')"
-            >
-              <ArrowPathIcon
-                class="size-icon icon-default"
-                :class="{ 'animate-spin': inFlight }"
-              />
-              <span>{{ _("Refresh") }}</span>
-            </button>
-          </div>
-        </div>
-      </template>
-      <div class="card">
-        <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
-             Table's default scroll wrapper leaks the table's natural width up to
-             <html>, which combined with SelectMenu's scrollIntoView() causes the
-             page to scroll horizontally when the dropdown opens. Keeping the
-             scroll container at this level (and isolating layout) avoids it. -->
-        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
-          <Table
-            noScroll
-            :emptyText='_("No connected clients.")'
-            class="!border-none !shadow-none"
-          >
-            <template #thead>
-              <tr>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
-                    {{ _("Protocol") }}
-                    <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
-                    {{ _("User") }}
-                    <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
-                    {{ _("Client") }}
-                    <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
-                    {{ _("Version") }}
-                    <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
-                    {{ _("Share") }}
-                    <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
-                    {{ _("Connected since") }}
-                    <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
-                    {{ _("Open files") }}
-                    <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
-                    {{ _("Encrypted") }}
-                    <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
-              </tr>
-            </template>
-            <template #tbody>
-              <tr v-for="client in sortedClients" :key="client.id">
-                <td>
-                  <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
-                </td>
-                <td>{{ fallback(client.user) }}</td>
-                <td>
-                  <div class="flex flex-col">
-                    <span class="font-mono">{{ client.ip }}</span>
-                    <span v-if="client.hostname" class="muted-text text-sm">
-                      {{ client.hostname }}
-                    </span>
-                  </div>
-                </td>
-                <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
-                <td>{{ fallback(client.share) }}</td>
-                <td>{{ formatDate(client.connectedSince) }}</td>
-                <td>{{ client.openFiles }}</td>
-                <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
-                <td class="button-group-row justify-end">
-                  <button
-                    v-if="client.protocol === 'samba'"
-                    class="btn btn-secondary btn-sm"
-                    @click="actions.kickClient(client)"
-                  >
-                    {{ _("Disconnect") }}
-                  </button>
-                </td>
-              </tr>
-            </template>
-          </Table>
-        </div>
-      </div>
-    </CardContainer>
+    <ConnectedClientsTableView
+      :clients="clients"
+      :inFlight="inFlight"
+      @refresh="actions.refreshNow()"
+      @kick="(c) => actions.kickClient(c)"
+    />
   </CenteredCardColumn>
 </template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import {
+  CardContainer,
+  CenteredCardColumn,
+  SelectMenu,
+  Table,
+  assertConfirm,
+  computedResult,
+  reportSuccess,
+  wrapActions,
+  type SelectMenuOption,
+} from "@45drives/houston-common-ui";
+import { getServer } from "@45drives/houston-common-lib";
+import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+
+import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
+import type {
+  ClientProtocol,
+  ConnectedClient,
+} from "@/tabs/connected-clients/data-types";
+import { useUserSettings } from "@/common/user-settings";
+
+const _ = cockpit.gettext;
+
+const userSettings = useUserSettings();
+
+const server = getServer();
+const manager = server.map((s) => new ConnectedClientsManager(s));
+
+type Filter = "all" | ClientProtocol;
+const filter = ref<Filter>("all");
+const filterOptions: SelectMenuOption<Filter>[] = [
+  { label: _("All"), value: "all" },
+  { label: _("Samba"), value: "samba" },
+  { label: _("NFS"), value: "nfs" },
+];
+
+const [clients, reloadClients] = computedResult<ConnectedClient[]>(
+  () => manager.andThen((m) => m.getClients()),
+  []
+);
+
+const filteredClients = computed(() =>
+  filter.value === "all"
+    ? clients.value
+    : clients.value.filter((c) => c.protocol === filter.value)
+);
+
+const refreshIntervalSeconds = computed(
+  () => userSettings.value.connectedClients.refreshIntervalSeconds
+);
+
+let refreshTimer: number | undefined;
+const startTimer = () => {
+  if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+  const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
+  refreshTimer = window.setInterval(() => {
+    actions.reloadClients();
+  }, ms);
+};
+
+onMounted(startTimer);
+onUnmounted(() => {
+  if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+});
+watch(refreshIntervalSeconds, startTimer);
+
+const kickClient = (client: ConnectedClient) =>
+  assertConfirm({
+    header: _("Disconnect Samba client?"),
+    body:
+      _("This drops all sessions from") +
+      ` ${client.ip}` +
+      ` (smbcontrol smbd kill-client-ip).`,
+    dangerous: true,
+  })
+    .andThen(() => manager)
+    .andThen((m) => m.kickSamba(client.ip))
+    .andThen(() => reloadClients())
+    .map(() => reportSuccess(_("Disconnected") + ` ${client.ip}`));
+
+const actions = wrapActions({
+  reloadClients,
+  kickClient,
+});
+
+const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
+const fallback = (v: string | null | undefined): string =>
+  v && v.length > 0 ? v : "—";
+</script>
+
+<template>
+  <CenteredCardColumn>
+    <CardContainer>
+      <template #header>
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <span>{{ _("Connected Clients") }}</span>
+          <div class="flex items-center gap-2">
+            <SelectMenu
+              v-model="filter"
+              :options="filterOptions"
+              class="min-w-[8rem]"
+            />
+            <button
+              class="btn btn-secondary inline-flex flex-row items-center gap-1"
+              @click="actions.reloadClients()"
+              :title="_('Refresh now')"
+            >
+              <ArrowPathIcon class="size-icon icon-default" />
+              <span>{{ _("Refresh") }}</span>
+            </button>
+          </div>
+        </div>
+      </template>
+      <div class="card">
+        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
+          <Table
+            emptyText="No connected clients."
+            noScroll
+            class="!border-none !shadow-none"
+          >
+            <template #thead>
+              <tr>
+                <th scope="col">{{ _("Protocol") }}</th>
+                <th scope="col">{{ _("User") }}</th>
+                <th scope="col">{{ _("Client") }}</th>
+                <th scope="col">{{ _("Version") }}</th>
+                <th scope="col">{{ _("Share") }}</th>
+                <th scope="col">{{ _("Connected since") }}</th>
+                <th scope="col">{{ _("Open files") }}</th>
+                <th scope="col">{{ _("Encrypted") }}</th>
+                <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+              </tr>
+            </template>
+            <template #tbody>
+              <tr v-for="client in filteredClients" :key="client.id">
+                <td>
+                  <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
+                </td>
+                <td>{{ fallback(client.user) }}</td>
+                <td>
+                  <div class="flex flex-col">
+                    <span class="font-mono">{{ client.ip }}</span>
+                    <span v-if="client.hostname" class="muted-text text-sm">
+                      {{ client.hostname }}
+                    </span>
+                  </div>
+                </td>
+                <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
+                <td>{{ fallback(client.share) }}</td>
+                <td>{{ formatDate(client.connectedSince) }}</td>
+                <td>{{ client.openFiles }}</td>
+                <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
+                <td class="button-group-row justify-end">
+                  <button
+                    v-if="client.protocol === 'samba'"
+                    class="btn btn-secondary btn-sm"
+                    @click="actions.kickClient(client)"
+                  >
+                    {{ _("Disconnect") }}
+                  </button>
+                </td>
+              </tr>
+            </template>
+          </Table>
+        </div>
+      </div>
+    </CardContainer>
+  </CenteredCardColumn>
+</template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -52,6 +52,16 @@ const clientLabel = (c: ConnectedClient): string => {
 };
 const shareLabel = (c: ConnectedClient, share: string): string =>
   `${share} · ${clientIdentity(c)}`;
+
+// Per-protocol toast titles. Strings stay as literal _() calls at each branch
+// so the gettext extractor catches them; using a key-driven helper would hide
+// them from the extraction tooling.
+const connectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client connected") : _("NFS client connected");
+const reconnectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client reconnected") : _("NFS client reconnected");
+const disconnectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client disconnected") : _("NFS client disconnected");
 const shareSet = (s: string | null): Set<string> =>
   new Set(s ? s.split(", ") : []);
 const sessionDiffers = (a: Date | null, b: Date | null): boolean => {
@@ -67,11 +77,11 @@ watch(clients, (newClients) => {
       const old = prev.get(c.id);
       if (!old) {
         pushNotification(
-          new Notification(_("Client connected"), clientLabel(c), "info")
+          new Notification(connectedTitle(c), clientLabel(c), "info")
         );
       } else if (sessionDiffers(c.connectedSince, old.connectedSince)) {
         pushNotification(
-          new Notification(_("Client reconnected"), clientLabel(c), "info")
+          new Notification(reconnectedTitle(c), clientLabel(c), "info")
         );
       } else {
         // Same id, same session — check for share-set delta. A user can
@@ -97,7 +107,7 @@ watch(clients, (newClients) => {
     for (const [id, c] of prev) {
       if (!newMap.has(id)) {
         pushNotification(
-          new Notification(_("Client disconnected"), clientLabel(c), "warning")
+          new Notification(disconnectedTitle(c), clientLabel(c), "warning")
         );
       }
     }
@@ -121,6 +131,7 @@ const refreshIntervalSeconds = computed(
 const inFlight = ref(false);
 const MIN_SPIN_MS = 400;
 let spinStartedAt = 0;
+let spinReleaseTimer: number | undefined;
 const beginInFlight = () => {
   inFlight.value = true;
   spinStartedAt = performance.now();
@@ -130,7 +141,10 @@ const releaseInFlight = () => {
   if (remaining <= 0) {
     inFlight.value = false;
   } else {
-    window.setTimeout(() => {
+    // Tracked so onUnmounted can clear it — otherwise a pending tick fires
+    // after teardown and Vue warns about mutating a destroyed component.
+    spinReleaseTimer = window.setTimeout(() => {
+      spinReleaseTimer = undefined;
       inFlight.value = false;
     }, remaining);
   }
@@ -168,6 +182,7 @@ const startTimer = () => {
 onMounted(startTimer);
 onUnmounted(() => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+  if (spinReleaseTimer !== undefined) window.clearTimeout(spinReleaseTimer);
 });
 watch(refreshIntervalSeconds, startTimer);
 

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -126,6 +126,16 @@ const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
 const fallback = (v: string | null | undefined): string =>
   v && v.length > 0 ? v : "—";
 
+// NFS Share is derived from active opens because the kernel doesn't expose a
+// per-client mount list for NFSv4 (no tcon concept). Surface that caveat as
+// a hover tooltip so operators don't read a blank cell as "not mounted".
+const shareTooltip = (c: ConnectedClient): string | undefined => {
+  if (c.protocol !== "nfs") return undefined;
+  return _(
+    'NFS: derived from active opens (the kernel doesn\'t expose a per-client mount list for NFSv4). An idle-but-mounted client will show "—" here even when connected; the column reflects what is currently being read/written, not what is mounted.'
+  );
+};
+
 // Column definitions for the sortable header row. Labels are wrapped in _()
 // at module init time, matching the convention used elsewhere in this project
 // (e.g. tabVisibilityOptions in UserSettingsView.vue).
@@ -211,7 +221,9 @@ const sortableColumns: { field: SortField; label: string }[] = [
                 </div>
               </td>
               <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
-              <td>{{ fallback(client.share) }}</td>
+              <td :title="shareTooltip(client)">
+                {{ fallback(client.share) }}
+              </td>
               <td>{{ formatDate(client.connectedSince) }}</td>
               <td>{{ client.openFiles }}</td>
               <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -240,6 +240,9 @@ const sortableColumns: { field: SortField; label: string }[] = [
           </template>
         </Table>
       </div>
+      <p class="text-muted text-sm mt-3">
+        {{ _("Note: NFS clients only appear while their NFSv4 lease is active (~90 s of recent I/O). An idle-but-mounted client may briefly disappear from this list until its next operation re-confirms the lease.") }}
+      </p>
     </div>
   </CardContainer>
 </template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -149,7 +149,7 @@ const sortableColumns: { field: SortField; label: string }[] = [
         <div class="flex items-center gap-2">
           <SelectMenu v-model="filter" :options="filterOptions" />
           <button
-            class="btn btn-secondary inline-flex flex-row items-center gap-1"
+            class="btn btn-secondary inline-flex flex-row items-center gap-1 text-base font-normal"
             @click="emit('refresh')"
             :title="_('Refresh now')"
           >

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import {
+  CardContainer,
+  SelectMenu,
+  Table,
+  type SelectMenuOption,
+} from "@45drives/houston-common-ui";
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/vue/20/solid";
+import { computed, ref } from "vue";
+
+import type {
+  ClientProtocol,
+  ConnectedClient,
+} from "@/tabs/connected-clients/data-types";
+
+const _ = cockpit.gettext;
+
+const props = defineProps<{
+  clients: ConnectedClient[];
+  inFlight: boolean;
+}>();
+
+const emit = defineEmits<{
+  refresh: [];
+  kick: [client: ConnectedClient];
+}>();
+
+type Filter = "all" | ClientProtocol;
+const filter = ref<Filter>("all");
+
+const filteredClients = computed(() =>
+  filter.value === "all"
+    ? props.clients
+    : props.clients.filter((c) => c.protocol === filter.value)
+);
+
+const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
+  const sambaCount = props.clients.filter((c) => c.protocol === "samba").length;
+  const nfsCount = props.clients.filter((c) => c.protocol === "nfs").length;
+  const total = props.clients.length;
+  return [
+    { label: `${_("All")} (${total})`, value: "all" },
+    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
+    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
+  ];
+});
+
+type SortField =
+  | "protocol"
+  | "user"
+  | "ip"
+  | "protocolVersion"
+  | "share"
+  | "connectedSince"
+  | "openFiles"
+  | "encrypted";
+type SortDir = "asc" | "desc";
+
+// `null` = unsorted (rows in arrival order from the manager). Clicking a
+// column cycles asc → desc → unsorted → asc, so users can clear a sort
+// without picking a different column.
+const sortBy = ref<SortField | null>("ip");
+const sortDir = ref<SortDir>("asc");
+
+const toggleSort = (field: SortField) => {
+  if (sortBy.value === field) {
+    if (sortDir.value === "asc") {
+      sortDir.value = "desc";
+    } else {
+      sortBy.value = null;
+    }
+  } else {
+    sortBy.value = field;
+    sortDir.value = "asc";
+  }
+};
+
+// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
+// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
+// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
+const ipSortKey = (ip: string): string => {
+  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return ip;
+  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
+};
+
+const sortValue = (c: ConnectedClient, f: SortField): string | number => {
+  switch (f) {
+    case "protocol":
+      return c.protocol;
+    case "user":
+      return c.user ?? "";
+    case "ip":
+      return ipSortKey(c.ip);
+    case "protocolVersion":
+      return c.protocolVersion;
+    case "share":
+      return c.share ?? "";
+    case "connectedSince":
+      return c.connectedSince ? c.connectedSince.getTime() : 0;
+    case "openFiles":
+      return c.openFiles;
+    case "encrypted":
+      return c.encrypted ? 1 : 0;
+  }
+};
+
+const sortedClients = computed(() => {
+  const f = sortBy.value;
+  if (f === null) return filteredClients.value;
+  const arr = [...filteredClients.value];
+  const dir = sortDir.value === "asc" ? 1 : -1;
+  return arr.sort((a, b) => {
+    const av = sortValue(a, f);
+    const bv = sortValue(b, f);
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    return String(av).localeCompare(String(bv)) * dir;
+  });
+});
+
+const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
+const fallback = (v: string | null | undefined): string =>
+  v && v.length > 0 ? v : "—";
+</script>
+
+<template>
+  <CardContainer>
+    <template #header>
+      <div class="flex items-center justify-between gap-3 flex-wrap">
+        <span>{{ _("Connected Clients") }}</span>
+        <div class="flex items-center gap-2">
+          <SelectMenu v-model="filter" :options="filterOptions" />
+          <button
+            class="btn btn-secondary inline-flex flex-row items-center gap-1"
+            @click="emit('refresh')"
+            :title="_('Refresh now')"
+          >
+            <ArrowPathIcon
+              class="size-icon icon-default"
+              :class="{ 'animate-spin': inFlight }"
+            />
+            <span>{{ _("Refresh") }}</span>
+          </button>
+        </div>
+      </div>
+    </template>
+    <div class="card">
+      <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
+           Table's default scroll wrapper leaks the table's natural width up to
+           <html>, which combined with SelectMenu's scrollIntoView() causes the
+           page to scroll horizontally when the dropdown opens. Keeping the
+           scroll container at this level (and isolating layout) avoids it. -->
+      <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
+        <Table
+          noScroll
+          :emptyText='_("No connected clients.")'
+          class="!border-none !shadow-none"
+        >
+          <template #thead>
+            <tr>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
+                  {{ _("Protocol") }}
+                  <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
+                  {{ _("User") }}
+                  <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
+                  {{ _("Client") }}
+                  <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
+                  {{ _("Version") }}
+                  <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
+                  {{ _("Share") }}
+                  <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
+                  {{ _("Connected since") }}
+                  <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
+                  {{ _("Open files") }}
+                  <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
+                  {{ _("Encrypted") }}
+                  <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+            </tr>
+          </template>
+          <template #tbody>
+            <tr v-for="client in sortedClients" :key="client.id">
+              <td>
+                <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
+              </td>
+              <td>{{ fallback(client.user) }}</td>
+              <td>
+                <div class="flex flex-col">
+                  <span class="font-mono">{{ client.ip }}</span>
+                  <span v-if="client.hostname" class="muted-text text-sm">
+                    {{ client.hostname }}
+                  </span>
+                </div>
+              </td>
+              <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
+              <td>{{ fallback(client.share) }}</td>
+              <td>{{ formatDate(client.connectedSince) }}</td>
+              <td>{{ client.openFiles }}</td>
+              <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
+              <td class="button-group-row justify-end">
+                <button
+                  v-if="client.protocol === 'samba'"
+                  class="btn btn-secondary btn-sm"
+                  @click="emit('kick', client)"
+                >
+                  {{ _("Disconnect") }}
+                </button>
+              </td>
+            </tr>
+          </template>
+        </Table>
+      </div>
+    </div>
+  </CardContainer>
+</template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -125,6 +125,20 @@ const sortedClients = computed(() => {
 const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
 const fallback = (v: string | null | undefined): string =>
   v && v.length > 0 ? v : "—";
+
+// Column definitions for the sortable header row. Labels are wrapped in _()
+// at module init time, matching the convention used elsewhere in this project
+// (e.g. tabVisibilityOptions in UserSettingsView.vue).
+const sortableColumns: { field: SortField; label: string }[] = [
+  { field: "protocol", label: _("Protocol") },
+  { field: "user", label: _("User") },
+  { field: "ip", label: _("Client") },
+  { field: "protocolVersion", label: _("Version") },
+  { field: "share", label: _("Share") },
+  { field: "connectedSince", label: _("Connected since") },
+  { field: "openFiles", label: _("Open files") },
+  { field: "encrypted", label: _("Encrypted") },
+];
 </script>
 
 <template>
@@ -162,63 +176,24 @@ const fallback = (v: string | null | undefined): string =>
         >
           <template #thead>
             <tr>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
-                  {{ _("Protocol") }}
-                  <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+              <th v-for="col in sortableColumns" :key="col.field" scope="col">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1"
+                  @click="toggleSort(col.field)"
+                >
+                  {{ col.label }}
+                  <ChevronUpIcon
+                    v-if="sortBy === col.field && sortDir === 'asc'"
+                    class="size-4"
+                  />
+                  <ChevronDownIcon
+                    v-else-if="sortBy === col.field && sortDir === 'desc'"
+                    class="size-4"
+                  />
                 </button>
               </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
-                  {{ _("User") }}
-                  <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
-                  {{ _("Client") }}
-                  <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
-                  {{ _("Version") }}
-                  <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
-                  {{ _("Share") }}
-                  <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
-                  {{ _("Connected since") }}
-                  <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
-                  {{ _("Open files") }}
-                  <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
-                  {{ _("Encrypted") }}
-                  <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+              <th scope="col" class="justify-end"><span class="sr-only">{{ _("Actions") }}</span></th>
             </tr>
           </template>
           <template #tbody>

--- a/file-sharing/src/tabs/connected-clients/ui/index.ts
+++ b/file-sharing/src/tabs/connected-clients/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as ConnectedClientsTabMain } from "./ConnectedClientsTabMain.vue";


### PR DESCRIPTION
## What this adds

A new **Connected Clients** tab that gives a live view of Samba sessions and NFSv4 clients currently holding open connections to the host. Closes the long-standing gap between "who *can* connect" (configured shares) and "who *is* connected right now" (live state).

**Why it matters**

- **Troubleshooting**: instantly see which clients are connected, what protocol versions they negotiated, whether sessions are encrypted, and how many files they have open.
- **Operational closure**: a Samba session can be disconnected from the UI (`smbcontrol smbd kill-client-ip`) without dropping to a shell.
- **Live feedback**: toast notifications fire as clients connect or disconnect between polls; titles are protocol-specific (`Samba client connected` / `NFS client connected`) so operators can tell at a glance which protocol an event came from.
- **Sortable, filterable**: click any column to sort (asc → desc → unsorted cycle); filter pill shows per-protocol counts (`All (4) / Samba (4) / NFS (0)`).
- **Fits the existing UX**: same Houston components, same data-layer patterns, same `ResultAsync` error path as the other tabs.

> **Tests** live in a companion PR: [#186 — Tests for Connected Clients](https://github.com/45Drives/cockpit-file-sharing/pull/186). 45 vitest cases covering the parsers (`smbstatus -j`, `/proc/fs/nfsd/clients` dump, `nmblookup` Node Status) and the logical-client aggregation. Kept separate to keep this PR focused; that branch is based on this one and should be merged after.

---

## Screenshots

<!--
Drop the actual images under each header. Captions describe what each shot
demonstrates conceptually — the actual rows, hosts, shares and counts will
naturally vary depending on the test environment.
-->

### 1. Live overview — the centerpiece
The Connected Clients tab with a mix of Samba and NFS rows visible. Shows the unified table at a glance — both protocols sharing the same column layout, with resolved hostnames, protocol versions, share names (where applicable), connect timestamps, open-file counts, and encryption state.

<img width="1314" height="472" alt="screenshot-1" src="https://github.com/user-attachments/assets/a0a476f6-e718-43bc-a22f-02d72c200c18" />

### 2. Filter dropdown open
The protocol filter pulled down so the per-bucket counts (All / Samba / NFS) are visible inline next to each label. Demonstrates that counts are part of the menu items themselves, not a hover tooltip.

<img width="295" height="246" alt="screenshot-2" src="https://github.com/user-attachments/assets/1c243433-ee48-4aa1-b5c6-815edfa9cecb" />

### 3. Live toast notifications
A connect/disconnect toast captured mid-fire, showing both the protocol-specific title and the identity string in the body. Easiest to capture right after kicking a Samba client — the disconnect→reconnect pair pops on subsequent polls.

<img width="432" height="158" alt="screenshot-3" src="https://github.com/user-attachments/assets/97f9b1ba-c761-43ee-9983-17c3cf07cd29" />

### 4. Settings panel
The user settings modal scrolled to the **Connected Clients** section, showing the three controls: tab visibility (auto / always / never), auto-refresh interval (5–60 s presets), and the notify-on-change toggle.

<img width="850" height="274" alt="screenshot-4" src="https://github.com/user-attachments/assets/59a3016c-043e-49da-b671-128118f78612" />

### 5. Disconnect confirmation modal
The kick confirmation dialog — shows the "dangerous action" styling and the explicit copy that sets the reconnect expectation (most CIFS clients auto-reconnect, so "disconnect" effectively means "force a fresh session").

<img width="922" height="243" alt="screenshot-5" src="https://github.com/user-attachments/assets/98ac80aa-e17d-4a2d-85a0-dc462b5b3225" />

### 6. Sorting indicator (optional)
A column header with the active sort chevron visible, demonstrating that column headers are interactive and the click cycle (asc → desc → unsorted) shows state.

<img width="275" height="150" alt="screenshot-6" src="https://github.com/user-attachments/assets/aebff455-5fae-4d8c-a943-f891acb947fa" />

---

## How it works

**Data sources** (read-only, no daemons added):

| Protocol | Source | Notes |
|---|---|---|
| Samba | `smbstatus -j` | Requires Samba 4.12+ for JSON output. Raw output is one record per `(session, tcon)` pair. |
| NFSv4 | `/proc/fs/nfsd/clients/*/{info,states}` + dentry mtime + `/proc/self/mountinfo` + `/etc/exports` | Linux 5.3+ kernel interface. Missing-dir or empty stdout → zero rows; older kernels degrade gracefully. NFSv3 has no kernel-side client identity and is intentionally not represented. Each client dir's mtime is also captured via `stat -c %Y` to surface a "connected since" timestamp (the kernel exposes no dedicated field for this — see *Trade-offs*). The dump also snapshots `/proc/self/mountinfo` and `/etc/exports` so we can derive the **Share** column for active opens — see "*NFS Share column*" in *Trade-offs*. |

**Row aggregation**: the manager collapses raw rows by `(protocol, user, ip)` — the "logical client" key — so a Samba session with 3 tcons (`IPC$` + 2 shares) renders as one row. Aggregated fields:
- `share` → comma-joined unique share names
- `connectedSince` → earliest tcon timestamp (Samba) / dentry mtime (NFS, one per logical client)
- `openFiles` → sum across tcons
- `encrypted` → `true` only if every tcon negotiated encryption (conservative)

**Per-row schema** is `ConnectedClient` (`protocol`, `user`, `ip`, `hostname`, `protocolVersion`, `share`, `connectedSince`, `openFiles`, `encrypted`, `id`). Fields a protocol doesn't expose render as `—` (NFS has no `user`). For Samba, `share` is the comma-joined list of tcon services; for NFS, `share` is derived from `/proc/fs/nfsd/clients/<id>/states` (each open file references a superblock + filename) joined with `/proc/self/mountinfo` and `/etc/exports`, so it reflects "exports the client is actively using right now". An idle-but-mounted NFS client shows `share=null` — see *Trade-offs*. Recent kernels wrap `/proc/fs/nfsd/clients/*/info` values in double quotes — the parser strips them so they don't leak into the UI as literal `"10.0.0.1` / `host"`.

**Hostname resolution** runs in a single batch per refresh: `getent hosts <ips…>` first (DNS / NSS), then falls back to `nmblookup -A` (NetBIOS Node Status) for IPs DNS couldn't answer. Whatever the resolver returns is shown verbatim — no stripping of search domains. Windows clients without PTR records are typically reached via NetBIOS; Linux CIFS clients without DNS PTR fall through to `—`.

**Polling**: a configurable interval drives `setInterval` (default 5 s; presets 5/10/15/30/60). An `inFlight` ref gates concurrent fetches — if a poll is still running when the next tick (or a manual refresh click) lands, the new one no-ops. Cockpit lacks first-class cancellation primitives, and cancel+restart wouldn't help on the typical hang case (DNS timeout, hung `nmblookup`) anyway.

**Notifications**: a Vue `watch` on the `clients` ref diffs consecutive polls and fires toasts for five event kinds:

| Event | Title | When | Color |
|---|---|---|---|
| Client connected | *Samba/NFS client connected* | New logical client (first time we see this `(protocol, user, ip)`) | info |
| Client disconnected | *Samba/NFS client disconnected* | Logical client gone | warning |
| Client reconnected | *Samba/NFS client reconnected* | Same logical client, different `connectedSince` — typical kick → auto-reconnect | info |
| Share connected | *Share connected* | Same client/session, a share appeared in the tcon list (Samba-only in practice) | info |
| Share disconnected | *Share disconnected* | Same client/session, a share dropped (Samba-only in practice) | info |

Toast titles are protocol-specific for client events so the operator sees at a glance whether a Samba or NFS client moved; share events stay generic since they're Samba-only. Bodies include the identity string (`user@hostname · share` for Samba, `hostname` for NFS), so the operator sees what was at stake. First load is silent (no baseline yet); the baseline is updated regardless of the notify-on-change setting so toggling it on doesn't backfire stale events. Users can opt out via *Settings → Connected Clients → Notify on connect/disconnect*.

**UI feedback**: the refresh-icon button shows `animate-spin` while a fetch is in flight, with a 400 ms minimum-spin floor so the user can perceive each tick — local fetches typically finish in <100 ms. The pending min-spin timer is cleared on `onUnmounted` so a tab tear-down mid-spin doesn't leak a callback that would mutate a destroyed component. The button itself uses `text-base font-normal` to override the inherited `text-header` cascade from `CardContainer`'s header slot, so it matches the default dialog button size (e.g. Cancel/Apply in the user settings modal).

**Filtering**: a `SelectMenu` at the top of the card switches between `All` / `Samba` / `NFS`. Labels include per-bucket counts so the user can see what each option contains before selecting (`"All (4) / Samba (4) / NFS (0)"`).

**Sorting**: every data column header is a button; clicking cycles **asc → desc → unsorted**, with a chevron indicator on the active column. Default initial sort is IP ascending — and the IP sort key zero-pads each IPv4 octet so a lexicographic compare orders numerically (`10.0.0.2` before `10.0.0.10`). Switching to a different column resets to asc. The eight column headers are rendered from a single column-config array via `v-for` — ~50 LOC of near-identical boilerplate collapsed to ~20.

**Tab visibility** follows the existing `auto/always/never` convention. Auto-mode probes for `smbstatus` or `/proc/fs/nfsd/clients` at startup and hides the tab if neither is present. **Setting `tabVisibility: "never"` in `/etc/cockpit-file-sharing.conf.json` disables the feature entirely** for everyone on the host — useful for sysadmins who want the code present but the surface area off.

---

## Trade-offs and explicit non-goals

- **No NFSv3 visibility.** The kernel doesn't track v3 clients by identity. Could be approximated with `ss` for active sockets but would be confusing alongside the v4 rows that have real client metadata.
- **NFS rows rotate in/out with the kernel lease.** `/proc/fs/nfsd/clients/` only contains clients with an active NFSv4 lease (~90s since last operation by default). An idle mount whose lease has lapsed will not appear in the table until the next I/O re-confirms it — any touch (`ls`, `stat`, opening a file) re-establishes the lease and the row reappears. This is intrinsic to NFSv4 + the kernel interface, not a bug in the view. It also means the *Connected since* timestamp for an NFS client resets each time the client re-confirms after expiry (the dentry is destroyed + recreated), which is technically correct but may surprise an operator who considers the mount "continuously mounted" from the client's side.
- **NFS Share column is "active opens only".** NFSv4 has no per-client mount list at the server (no tcon concept like SMB), so we can only populate the Share column by inferring from open files: each entry in `/proc/fs/nfsd/clients/<id>/states` references a `(superblock, relative-path)` pair, and joining with `/proc/self/mountinfo` + `/etc/exports` lets us name the export. The upshot: an idle-but-mounted NFS client shows `—` here even when connected; the column reflects "what is currently being read/written", not "what is mounted". The UI surfaces this via a hover tooltip on NFS Share cells so a blank cell doesn't read as "not mounted".
- **`smbstatus -j` only.** Older Samba (pre-4.12) had only text output. JSON keeps the parser honest and matches the direction newer Houston features are heading.
- **NFS `connectedSince` is derived, not officially API.** The kernel has no dedicated "connected at" field — `seconds from last renew` in `info` resets every NFSv4 lease renewal (~90 s) and is not what an operator wants. We use the `/proc/fs/nfsd/clients/<id>/` dentry mtime instead: it's set when the kernel creates the entry on first client confirm and only changes if the entry is destroyed and recreated (lease expiry + reconnect, or kernel restart) — semantically the right answer. It's not a documented kernel API, but the behavior has been stable across many years and the failure mode is graceful (a wrong timestamp, never a crash). Naive ISO strings without a TZ offset would be interpreted as browser-local — the Samba parser only consumes timestamps with explicit offsets (`...+00:00`), which is what `smbstatus -j` emits.
- **"Disconnect" is a session reset, not a ban.** Most CIFS clients (macOS Finder, Linux cifs-utils, Windows) auto-reconnect within seconds — exactly what the live notifications surface (you see one Disconnect toast immediately followed by a Connect toast on the next poll). The confirmation copy sets this expectation explicitly.
- **Open-files count for NFS is approximate.** We count lines in the kernel `states` file, which mixes opens + locks + delegations. Precise breakdown is a follow-up.
- **Hostname resolution doesn't try mDNS or DHCP-lease lookups.** Tried; DHCP leases aren't reachable from the host, and Avahi requires extra packages that aren't currently in the dependency set.
- **Row aggregation by `(protocol, user, ip)`** means two distinct NFSv4 clients sharing an IP (rare — different containers/namespaces from the same host) would be merged. Edge case, accepted for v1.
- **No tests in this PR.** The parsers (`samba-clients.ts`, `nfs-clients.ts`) and the aggregation logic are pure functions and very test-friendly. Deferred to a follow-up PR ([#186](https://github.com/45Drives/cockpit-file-sharing/pull/186)) to keep this one focused and reviewable.

---

## Compatibility

- **Cockpit**: targets the current `houston-common` workspace as referenced in `.gitmodules`. Uses existing `SelectMenu`, `Table`, `CardContainer`, `CenteredCardColumn`, `pushNotification`, `Notification`, `wrapActions`, `computedResult`, `assertConfirm`, `reportSuccess`. Nothing new added to houston-common.
- **Samba**: `smbstatus -j` requires Samba 4.12+ (Ubuntu 20.04+, Rocky 8+). Older versions silently produce zero rows.
- **NFS**: `/proc/fs/nfsd/clients` requires Linux 5.3+ kernel running the NFS server. Older kernels silently produce zero rows.
- **Privileges**: all subprocess calls use `superuser: "try"` — matches the rest of the file-sharing codebase.
- **i18n**: all user-facing strings (column headers, toast titles, settings labels, the screen-reader-only "Actions" header, confirmation copy) go through `cockpit.gettext`. The protocol-specific toast titles are placed as literal `_()` calls at each branch so the gettext extractor catches them.

---

## Files changed

```
file-sharing/src/App.vue                                 (+42 lines: tab registration + auto-detection)
file-sharing/src/common/user-settings.ts                 (+27 lines: connectedClients sub-tree + merge logic)
file-sharing/src/common/ui/UserSettingsView.vue          (+33 lines: settings panel section)
file-sharing/src/tabs/connected-clients/                 (new dir)
  ├── data-types.ts                                      (ConnectedClient interface)
  ├── samba-clients.ts                                   (smbstatus -j parser + kick fn)
  ├── nfs-clients.ts                                     (/proc/fs/nfsd/clients parser + dentry-mtime capture)
  ├── hostname-resolver.ts                               (DNS → NetBIOS fallback chain)
  ├── connected-clients-manager.ts                       (façade + logical-client aggregation)
  └── ui/
      ├── ConnectedClientsTabMain.vue                    (orchestrator: manager, polling, notifications, kick)
      ├── ConnectedClientsTableView.vue                  (presentational: filter, sort, table)
      └── index.ts
```

No changes to packaging, manifest dependencies (the existing `samba-common-bin` and `nfs-kernel-server` requirements already cover us), or build pipeline.

---

## How to test

```bash
# Build and install to user-dir overlay (won't touch /usr/share/cockpit/file-sharing)
git checkout feat/connected-clients
make install-local

# Restart cockpit if needed
sudo systemctl restart cockpit.socket
```

Then in Cockpit → File Sharing → Connected Clients:

1. Mount a Samba share from another host → row appears within ≤5 s, with comma-joined share names if multiple shares are mounted from the same user/IP. The toast title reads "Samba client connected".
2. Open a file from the client → the *Open files* count updates on next poll.
3. Click any column header → rows sort (IP sort is numeric-by-octet, not lexicographic); click again to flip direction; third click clears the sort.
4. Click **Disconnect** on a row → confirm → the session is killed; most clients auto-reconnect, surfacing as a "Samba client disconnected" toast followed by a "Samba client reconnected" toast on subsequent polls.
5. Open Settings (cog, bottom-right) → adjust *Auto-refresh interval*, toggle *Notify on connect/disconnect*, or set *Connected Clients Tab Visibility* to `Always Hide` to disable the feature entirely.
6. For an NFSv4 client: mount `nfs4://server/export` from another host → row appears with `Linux NFSv4.x <hostname>` parsed from the kernel's client-info dump, *Connected since* populated from the dentry mtime, and toast title "NFS client connected".

---

## Follow-up work (out of scope here)

- **Unit tests** — done, in [#186](https://github.com/45Drives/cockpit-file-sharing/pull/186) (45 cases covering parsers, NetBIOS resolver parsing, logical-client aggregation, and the new quote-strip + dentry-mtime paths).
- **Optional reverse-DNS opt-out** in user settings for environments that don't want extra NSS traffic per poll.
- **Precise NFS state breakdown** (opens vs. locks vs. delegations) instead of a unified line count.
- **Re-investigate `SelectMenu`'s `scrollIntoView` behavior in `houston-common-ui`**: this PR works around a latent horizontal-overflow interaction by passing `noScroll` to `Table` (see commit `f719342`). The underlying houston-common-ui Listbox could be improved to skip `scrollIntoView` when the option is already in view; happy to file that as a separate issue against the lib.
- **Improve iSCSI driver detection path**: orthogonal observation while testing — the iSCSI tab's `ISCSIDriverSingleServer` throws `ProcessError` from its constructor when SCST isn't installed, surfacing as a toast on page load for any host without SCST. The app-level `iscsiConfigured()` probe handles this cleanly via `Result`; the driver's constructor should do the same. Not touched here to stay focused, but worth filing.


