### PR TITLE
Tests for Connected Clients (depends on #185)

### DIFF
--- a/file-sharing/src/App.vue
+++ b/file-sharing/src/App.vue
@@ -13,6 +13,7 @@ import {
 import { SambaTabMain } from "@/tabs/samba/ui";
 import ISCSITabMain from "@/tabs/iSCSI/ui/ISCSITabMain.vue";
 import { NFSTabMain } from "@/tabs/nfs/ui";
+import { ConnectedClientsTabMain } from "@/tabs/connected-clients/ui";
 import UserSettingsView from "@/common/ui/UserSettingsView.vue";
 import { ref, computed, watchEffect, type WatchStopHandle, onUnmounted, watch } from "vue";
 import { Cog8ToothIcon } from "@heroicons/vue/20/solid";
@@ -35,6 +36,7 @@ const showSambaTab = ref(true);
 const showNfsTab = ref(true);
 const showIscsiTab = ref(true);
 const showS3Tab = ref(true);
+const showConnectedClientsTab = ref(true);
 const sambaConfigured = (): ResultAsync<boolean, never> => {
   return getServer()
     .andThen((server) => server.execute(new BashCommand("command -v net")))
@@ -67,6 +69,21 @@ const s3Configured = (): ResultAsync<boolean, never> => {
     ),
     () => null
   ).orElse((_) => ok(false));
+};
+
+// Shown when either smbstatus is present OR the kernel NFSv4 clients dir
+// exists. Either signal means we have at least one source of live data.
+const connectedClientsConfigured = (): ResultAsync<boolean, never> => {
+  return getServer()
+    .andThen((server) =>
+      server.execute(
+        new BashCommand(
+          "command -v smbstatus >/dev/null 2>&1 || [ -d /proc/fs/nfsd/clients ]"
+        )
+      )
+    )
+    .map((_) => true)
+    .orElse((_) => ok(false));
 };
 
 let watchStopHandle: WatchStopHandle;
@@ -177,6 +194,21 @@ globalProcessingWrapPromise(useUserSettings(true)).then((userSettings) => {
           );
           break;
       }
+      switch (userSettings.connectedClients.tabVisibility) {
+        case "always":
+          showConnectedClientsTab.value = true;
+          break;
+        case "never":
+          showConnectedClientsTab.value = false;
+          break;
+        case "auto":
+          globalProcessingWrapPromise(
+            connectedClientsConfigured()
+              .map((value) => (showConnectedClientsTab.value = value))
+              .unwrapOr(null)
+          );
+          break;
+      }
     },
     { immediate: true }
   );
@@ -216,7 +248,15 @@ const visibleTabs = computed<HoustonAppTabEntry[]>(() => [
           component: S3ManagementMain,
         },
       ]
-    : [])
+    : []),
+  ...(showConnectedClientsTab.value
+    ? [
+        {
+          label: "Connected Clients",
+          component: ConnectedClientsTabMain,
+        },
+      ]
+    : []),
 ]);
 </script>
 

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -43,6 +43,14 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
     value: "never",
   },
 ];
+
+const refreshIntervalOptions: SelectMenuOption<number>[] = [
+  { label: _("5 seconds"), value: 5 },
+  { label: _("10 seconds"), value: 10 },
+  { label: _("15 seconds"), value: 15 },
+  { label: _("30 seconds"), value: 30 },
+  { label: _("60 seconds"), value: 60 },
+];
 </script>
 
 <template>
@@ -145,6 +153,25 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
         <SelectMenu
           v-model="tempUserSettings.s3.tabVisibility"
           :options="tabVisibilityOptions"
+        />
+      </InputLabelWrapper>
+      <div class="text-header">{{ _("Connected Clients") }}</div>
+      <InputLabelWrapper>
+        <template #label>
+          {{ _("Connected Clients Tab Visibility") }}
+        </template>
+        <SelectMenu
+          v-model="tempUserSettings.connectedClients.tabVisibility"
+          :options="tabVisibilityOptions"
+        />
+      </InputLabelWrapper>
+      <InputLabelWrapper>
+        <template #label>
+          {{ _("Auto-refresh interval") }}
+        </template>
+        <SelectMenu
+          v-model="tempUserSettings.connectedClients.refreshIntervalSeconds"
+          :options="refreshIntervalOptions"
         />
       </InputLabelWrapper>
     </div>

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -174,6 +174,12 @@ const refreshIntervalOptions: SelectMenuOption<number>[] = [
           :options="refreshIntervalOptions"
         />
       </InputLabelWrapper>
+      <ToggleSwitch v-model="tempUserSettings.connectedClients.notifyOnChange">
+        {{ _("Notify on connect/disconnect") }}
+        <template #description>
+          {{ _("Show a toast when a client connects or disconnects between polls. Latency is bounded by the auto-refresh interval.") }}
+        </template>
+      </ToggleSwitch>
     </div>
     <template #footer>
       <div class="button-group-row justify-end">

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -119,10 +119,11 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             tabVisibility:
               contents.connectedClients?.tabVisibility ||
               defaultSettings().connectedClients.tabVisibility,
+            // `??` not `||` here and below: 0 / false are valid user choices
+            // (even if not currently exposed in the UI), don't overwrite with default.
             refreshIntervalSeconds:
-              contents.connectedClients?.refreshIntervalSeconds ||
+              contents.connectedClients?.refreshIntervalSeconds ??
               defaultSettings().connectedClients.refreshIntervalSeconds,
-            // `??` not `||`: false is a valid user choice, don't overwrite with default.
             notifyOnChange:
               contents.connectedClients?.notifyOnChange ??
               defaultSettings().connectedClients.notifyOnChange,

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -28,6 +28,14 @@ export type UserSettings = {
     tabVisibility: TabVisibility;
   };
   /**
+   * Connected-clients tab settings
+   */
+  connectedClients: {
+    tabVisibility: TabVisibility;
+    /** Auto-refresh interval in seconds. */
+    refreshIntervalSeconds: number;
+  };
+  /**
    * iSCSI-specific settings
    */
   iscsi: {
@@ -62,6 +70,10 @@ const defaultSettings = (): UserSettings => ({
   },
   s3: {
     tabVisibility: "auto",
+  },
+  connectedClients: {
+    tabVisibility: "auto",
+    refreshIntervalSeconds: 30,
   },
   iscsi: {
     // confPath: "/etc/scst/cockpit-iscsi.conf",
@@ -99,6 +111,14 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
           },
           s3: {
             tabVisibility: contents.s3?.tabVisibility || defaultSettings().s3.tabVisibility,
+          },
+          connectedClients: {
+            tabVisibility:
+              contents.connectedClients?.tabVisibility ||
+              defaultSettings().connectedClients.tabVisibility,
+            refreshIntervalSeconds:
+              contents.connectedClients?.refreshIntervalSeconds ||
+              defaultSettings().connectedClients.refreshIntervalSeconds,
           },
           iscsi: {
             // confPath: contents.iscsi?.confPath || defaultSettings().iscsi.confPath,

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -34,6 +34,8 @@ export type UserSettings = {
     tabVisibility: TabVisibility;
     /** Auto-refresh interval in seconds. */
     refreshIntervalSeconds: number;
+    /** Whether to push toast notifications when clients connect or disconnect between polls. */
+    notifyOnChange: boolean;
   };
   /**
    * iSCSI-specific settings
@@ -73,7 +75,8 @@ const defaultSettings = (): UserSettings => ({
   },
   connectedClients: {
     tabVisibility: "auto",
-    refreshIntervalSeconds: 30,
+    refreshIntervalSeconds: 5,
+    notifyOnChange: true,
   },
   iscsi: {
     // confPath: "/etc/scst/cockpit-iscsi.conf",
@@ -119,6 +122,10 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             refreshIntervalSeconds:
               contents.connectedClients?.refreshIntervalSeconds ||
               defaultSettings().connectedClients.refreshIntervalSeconds,
+            // `??` not `||`: false is a valid user choice, don't overwrite with default.
+            notifyOnChange:
+              contents.connectedClients?.notifyOnChange ??
+              defaultSettings().connectedClients.notifyOnChange,
           },
           iscsi: {
             // confPath: contents.iscsi?.confPath || defaultSettings().iscsi.confPath,

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.test.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.test.ts
@@ -1,0 +1,116 @@
+import { suite, test, expect } from "vitest";
+import { aggregateByLogicalClient } from "./connected-clients-manager";
+import type { ConnectedClient } from "./data-types";
+
+const makeRow = (overrides: Partial<ConnectedClient>): ConnectedClient => ({
+  id: "stub",
+  protocol: "samba",
+  user: "alice",
+  ip: "10.0.0.1",
+  hostname: null,
+  protocolVersion: "SMB3_11",
+  share: null,
+  connectedSince: null,
+  openFiles: 0,
+  encrypted: true,
+  ...overrides,
+});
+
+suite("connected-clients-manager aggregateByLogicalClient", () => {
+  test("empty input → empty output", () => {
+    expect(aggregateByLogicalClient([])).toEqual([]);
+  });
+
+  test("single row passes through with id rewritten to logical-client key", () => {
+    const input = [makeRow({ share: "Public" })];
+    const out = aggregateByLogicalClient(input);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe("samba:alice:10.0.0.1");
+    expect(out[0]!.share).toBe("Public");
+  });
+
+  test("multi-tcon merge: same (protocol, user, ip) collapses into one row", () => {
+    const input = [
+      makeRow({ share: "IPC$", openFiles: 0, encrypted: true }),
+      makeRow({ share: "Resilio", openFiles: 2, encrypted: true }),
+      makeRow({ share: "Downloads", openFiles: 5, encrypted: true }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.share).toBe("IPC$, Resilio, Downloads");
+    expect(out[0]!.openFiles).toBe(7);
+    expect(out[0]!.encrypted).toBe(true);
+  });
+
+  test("encryption is conservative AND: any unencrypted tcon → row encrypted false", () => {
+    const input = [
+      makeRow({ share: "A", encrypted: true }),
+      makeRow({ share: "B", encrypted: false }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out[0]!.encrypted).toBe(false);
+  });
+
+  test("connectedSince is the earliest non-null timestamp across tcons", () => {
+    const earlier = new Date("2026-01-01T00:00:00Z");
+    const middle = new Date("2026-01-01T00:05:00Z");
+    const later = new Date("2026-01-01T00:10:00Z");
+    const input = [
+      makeRow({ share: "A", connectedSince: middle }),
+      makeRow({ share: "B", connectedSince: earlier }),
+      makeRow({ share: "C", connectedSince: later }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out[0]!.connectedSince?.toISOString()).toBe(earlier.toISOString());
+  });
+
+  test("null connectedSince values are ignored in the earliest computation", () => {
+    const t = new Date("2026-01-01T00:00:00Z");
+    const input = [
+      makeRow({ share: "A", connectedSince: null }),
+      makeRow({ share: "B", connectedSince: t }),
+    ];
+    expect(aggregateByLogicalClient(input)[0]!.connectedSince?.toISOString()).toBe(t.toISOString());
+  });
+
+  test("different users from same IP do NOT merge", () => {
+    const input = [
+      makeRow({ user: "alice", share: "A" }),
+      makeRow({ user: "bob", share: "B" }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out).toHaveLength(2);
+  });
+
+  test("different protocols at same (user, ip) do NOT merge", () => {
+    const input = [
+      makeRow({ protocol: "samba", share: "A" }),
+      makeRow({ protocol: "nfs", user: null, share: null }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out).toHaveLength(2);
+  });
+
+  test("duplicate shares within a single client are deduped in the joined string", () => {
+    const input = [
+      makeRow({ share: "Public" }),
+      makeRow({ share: "Public" }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out[0]!.share).toBe("Public");
+  });
+
+  test("rows with null share are filtered out of the joined share string", () => {
+    const input = [
+      makeRow({ share: null }),
+      makeRow({ share: "Real" }),
+    ];
+    const out = aggregateByLogicalClient(input);
+    expect(out[0]!.share).toBe("Real");
+  });
+
+  test("all-null shares yield share = null on the merged row", () => {
+    const input = [makeRow({ share: null }), makeRow({ share: null })];
+    expect(aggregateByLogicalClient(input)[0]!.share).toBeNull();
+  });
+});

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -1,0 +1,19 @@
+import { ProcessError, Server } from "@45drives/houston-common-lib";
+import { ResultAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba-clients";
+import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
+
+export class ConnectedClientsManager {
+  constructor(public server: Server) {}
+
+  getClients(): ResultAsync<ConnectedClient[], ProcessError> {
+    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)]).map(
+      ([samba, nfs]) => [...samba, ...nfs]
+    );
+  }
+
+  kickSamba(ip: string): ResultAsync<void, ProcessError> {
+    return kickSambaClient(this.server, ip);
+  }
+}

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -1,16 +1,28 @@
-import { ProcessError, Server } from "@45drives/houston-common-lib";
+import { ParsingError, ProcessError, Server } from "@45drives/houston-common-lib";
 import { ResultAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba-clients";
 import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
+import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
+
+export type GetClientsError = ProcessError | ParsingError;
 
 export class ConnectedClientsManager {
   constructor(public server: Server) {}
 
-  getClients(): ResultAsync<ConnectedClient[], ProcessError> {
-    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)]).map(
-      ([samba, nfs]) => [...samba, ...nfs]
-    );
+  getClients(): ResultAsync<ConnectedClient[], GetClientsError> {
+    return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)])
+      .map(([samba, nfs]) => [...samba, ...nfs])
+      .andThen((clients) =>
+        resolveHostnames(this.server, clients.map((c) => c.ip)).map((map) =>
+          clients.map((c) => ({
+            // NFS already extracts the hostname from the client `name`
+            // field — only fall back to reverse DNS when we have nothing.
+            ...c,
+            hostname: c.hostname ?? map.get(c.ip) ?? null,
+          }))
+        )
+      );
   }
 
   kickSamba(ip: string): ResultAsync<void, ProcessError> {

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -14,7 +14,7 @@ type GetClientsError = ProcessError | ParsingError;
  * this aggregation they'd appear as separate rows and a single kick would
  * fan out into multiple connect/disconnect notifications.
  */
-function aggregateByLogicalClient(rows: ConnectedClient[]): ConnectedClient[] {
+export function aggregateByLogicalClient(rows: ConnectedClient[]): ConnectedClient[] {
   const groups = new Map<string, ConnectedClient[]>();
   for (const r of rows) {
     const key = `${r.protocol}:${r.user ?? ""}:${r.ip}`;

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -5,7 +5,7 @@ import { getSambaClients, kickSambaClient } from "@/tabs/connected-clients/samba
 import { getNfsClients } from "@/tabs/connected-clients/nfs-clients";
 import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
 
-export type GetClientsError = ProcessError | ParsingError;
+type GetClientsError = ProcessError | ParsingError;
 
 /**
  * Collapses raw per-tcon rows (Samba) and per-client rows (NFS) into one row

--- a/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
+++ b/file-sharing/src/tabs/connected-clients/connected-clients-manager.ts
@@ -7,12 +7,49 @@ import { resolveHostnames } from "@/tabs/connected-clients/hostname-resolver";
 
 export type GetClientsError = ProcessError | ParsingError;
 
+/**
+ * Collapses raw per-tcon rows (Samba) and per-client rows (NFS) into one row
+ * per logical client, keyed by (protocol, user, ip). A user authenticated to
+ * Samba from one IP typically has 2+ tcons (IPC$ plus each share); without
+ * this aggregation they'd appear as separate rows and a single kick would
+ * fan out into multiple connect/disconnect notifications.
+ */
+function aggregateByLogicalClient(rows: ConnectedClient[]): ConnectedClient[] {
+  const groups = new Map<string, ConnectedClient[]>();
+  for (const r of rows) {
+    const key = `${r.protocol}:${r.user ?? ""}:${r.ip}`;
+    const arr = groups.get(key);
+    if (arr) arr.push(r);
+    else groups.set(key, [r]);
+  }
+  const out: ConnectedClient[] = [];
+  for (const [key, members] of groups) {
+    const first = members[0]!;
+    const shares = [...new Set(members.map((m) => m.share).filter((s): s is string => !!s))];
+    const dates = members
+      .map((m) => m.connectedSince)
+      .filter((d): d is Date => d !== null);
+    out.push({
+      ...first,
+      id: key,
+      share: shares.length > 0 ? shares.join(", ") : null,
+      connectedSince:
+        dates.length > 0 ? new Date(Math.min(...dates.map((d) => d.getTime()))) : null,
+      openFiles: members.reduce((s, m) => s + m.openFiles, 0),
+      // Conservative: only "Yes" if every tcon negotiated encryption. A
+      // partial encryption state should NOT show "Yes" to the operator.
+      encrypted: members.every((m) => m.encrypted),
+    });
+  }
+  return out;
+}
+
 export class ConnectedClientsManager {
   constructor(public server: Server) {}
 
   getClients(): ResultAsync<ConnectedClient[], GetClientsError> {
     return ResultAsync.combine([getSambaClients(this.server), getNfsClients(this.server)])
-      .map(([samba, nfs]) => [...samba, ...nfs])
+      .map(([samba, nfs]) => aggregateByLogicalClient([...samba, ...nfs]))
       .andThen((clients) =>
         resolveHostnames(this.server, clients.map((c) => c.ip)).map((map) =>
           clients.map((c) => ({

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -1,0 +1,19 @@
+export type ClientProtocol = "samba" | "nfs";
+
+export interface ConnectedClient {
+  /** Stable per-row key (e.g. `${protocol}:${sessionId}/${tconId}` or `nfs:${clientId}`) */
+  id: string;
+  protocol: ClientProtocol;
+  /** Authenticated username, when the protocol exposes one (Samba only today). */
+  user: string | null;
+  ip: string;
+  hostname: string | null;
+  /** e.g. "SMB3_11", "NFSv4.2". */
+  protocolVersion: string;
+  /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
+  share: string | null;
+  /** When the session/tcon was established. NFS clients have no exposed timestamp. */
+  connectedSince: Date | null;
+  openFiles: number;
+  encrypted: boolean;
+}

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -10,7 +10,13 @@ export interface ConnectedClient {
   hostname: string | null;
   /** e.g. "SMB3_11", "NFSv4.2". */
   protocolVersion: string;
-  /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
+  /**
+   * Samba: share name per tcon. NFS: comma-joined list of exports the client
+   * is *actively using* (derived by mapping each open file's superblock back
+   * to a mount path and then to an /etc/exports entry). NFSv4 has no per-
+   * client mount list at the server, so an idle-but-mounted NFS client shows
+   * null here. The UI surfaces this caveat via a hover tooltip.
+   */
   share: string | null;
   /**
    * When the session/tcon was established. Samba surfaces this directly per

--- a/file-sharing/src/tabs/connected-clients/data-types.ts
+++ b/file-sharing/src/tabs/connected-clients/data-types.ts
@@ -12,7 +12,14 @@ export interface ConnectedClient {
   protocolVersion: string;
   /** Samba: share name per tcon. NFS: null (kernel doesn't surface per-export here). */
   share: string | null;
-  /** When the session/tcon was established. NFS clients have no exposed timestamp. */
+  /**
+   * When the session/tcon was established. Samba surfaces this directly per
+   * tcon; NFS has no dedicated "connected at" field (the kernel's only time
+   * value is `seconds from last renew`, which resets on every NFSv4 lease
+   * renewal), so we use the `/proc/fs/nfsd/clients/<id>/` dentry mtime as a
+   * proxy — it's set on first confirm and only changes on lease expiry +
+   * reconnect, which matches the operator's notion of "connected since".
+   */
   connectedSince: Date | null;
   openFiles: number;
   encrypted: boolean;

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.test.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.test.ts
@@ -1,0 +1,63 @@
+import { suite, test, expect } from "vitest";
+import { parseNmblookup } from "./hostname-resolver";
+
+suite("hostname-resolver parseNmblookup", () => {
+  test("empty input yields null for every requested IP", () => {
+    const map = parseNmblookup("", ["10.0.0.1", "10.0.0.2"]);
+    expect(map.get("10.0.0.1")).toBeNull();
+    expect(map.get("10.0.0.2")).toBeNull();
+  });
+
+  test("single host with <00> record resolves to its NetBIOS name", () => {
+    const stdout = [
+      "---IP:192.168.3.5---",
+      "Looking up status of 192.168.3.5",
+      "\tWINBOX          <00> -         B <ACTIVE>",
+      "\tWORKGROUP       <00> - <GROUP> B <ACTIVE>",
+    ].join("\n");
+    const map = parseNmblookup(stdout, ["192.168.3.5"]);
+    expect(map.get("192.168.3.5")).toBe("WINBOX");
+  });
+
+  test("<GROUP> records are skipped — workgroup name must not become hostname", () => {
+    const stdout = [
+      "---IP:10.0.0.1---",
+      "\tWORKGROUP       <00> - <GROUP> B <ACTIVE>",
+      "\tHOSTNAME        <00> -         B <ACTIVE>",
+    ].join("\n");
+    expect(parseNmblookup(stdout, ["10.0.0.1"]).get("10.0.0.1")).toBe("HOSTNAME");
+  });
+
+  test("non-responding host stays null", () => {
+    const stdout = [
+      "---IP:10.0.0.7---",
+      "Looking up status of 10.0.0.7",
+      "No reply from 10.0.0.7",
+    ].join("\n");
+    expect(parseNmblookup(stdout, ["10.0.0.7"]).get("10.0.0.7")).toBeNull();
+  });
+
+  test("mixed batch: some resolve, some don't", () => {
+    const stdout = [
+      "---IP:10.0.0.1---",
+      "\tONE             <00> -         B <ACTIVE>",
+      "---IP:10.0.0.2---",
+      "No reply from 10.0.0.2",
+      "---IP:10.0.0.3---",
+      "\tTHREE           <00> -         B <ACTIVE>",
+    ].join("\n");
+    const map = parseNmblookup(stdout, ["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    expect(map.get("10.0.0.1")).toBe("ONE");
+    expect(map.get("10.0.0.2")).toBeNull();
+    expect(map.get("10.0.0.3")).toBe("THREE");
+  });
+
+  test("only the first <00> non-group record is used per host", () => {
+    const stdout = [
+      "---IP:10.0.0.1---",
+      "\tFIRST           <00> -         B <ACTIVE>",
+      "\tSECOND          <00> -         B <ACTIVE>",
+    ].join("\n");
+    expect(parseNmblookup(stdout, ["10.0.0.1"]).get("10.0.0.1")).toBe("FIRST");
+  });
+});

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
@@ -1,0 +1,115 @@
+import { BashCommand, ProcessError, Server } from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+
+const superuserOpts = { superuser: "try" as const };
+
+/**
+ * Reverse-resolves IPs to hostnames. Tries DNS first via NSS (`getent
+ * hosts`), then falls back to NetBIOS Node Status (`nmblookup -A`) for IPs
+ * DNS can't answer. NetBIOS catches Windows clients that have no PTR record
+ * but always respond to NBT name queries; Linux CIFS clients usually fail
+ * both and are left as null (UI shows "—").
+ *
+ * Returns whatever the resolver says verbatim — if DNS returns a short name
+ * (`quim`) that's what you'll get; if it returns an FQDN that's what you'll
+ * get; NetBIOS names are always returned in their registered short form.
+ */
+export function resolveHostnames(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  const unique = [...new Set(ips.filter((ip) => ip.length > 0))];
+  if (unique.length === 0) return okAsync(new Map());
+
+  return resolveViaDns(server, unique).andThen((dnsMap) => {
+    const unresolved = unique.filter((ip) => !dnsMap.get(ip));
+    if (unresolved.length === 0) return okAsync(dnsMap);
+    return resolveViaNetBIOS(server, unresolved).map((nbMap) => {
+      for (const [ip, name] of nbMap) if (name) dnsMap.set(ip, name);
+      return dnsMap;
+    });
+  });
+}
+
+function resolveViaDns(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  // getent hosts accepts multiple IPs in one call. `|| true` keeps the
+  // command zero-exit even when one or more IPs don't resolve.
+  const args = ips.map((_, i) => `"$${i + 1}"`).join(" ");
+  const script = `getent hosts ${args} 2>/dev/null || true`;
+
+  return server
+    .execute(new BashCommand(script, ips, superuserOpts))
+    .map((proc) => {
+      const out = new Map<string, string | null>();
+      for (const ip of ips) out.set(ip, null);
+      for (const line of proc.getStdout().split("\n")) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 2) continue;
+        const ip = parts[0];
+        const name = parts[1];
+        if (!ip || !name) continue;
+        out.set(ip, name);
+      }
+      return out;
+    })
+    .orElse(() => okAsync(new Map()));
+}
+
+/**
+ * NetBIOS Node Status query — asks each host directly for its registered
+ * names. The `<00>` record (without the `<GROUP>` tag) is the host's
+ * computer name. Silently skipped if nmblookup isn't installed.
+ */
+function resolveViaNetBIOS(
+  server: Server,
+  ips: string[]
+): ResultAsync<Map<string, string | null>, ProcessError> {
+  const empty = () => {
+    const m = new Map<string, string | null>();
+    for (const ip of ips) m.set(ip, null);
+    return m;
+  };
+
+  // Loop in the shell so a non-responding host (nmblookup exit != 0) doesn't
+  // abort the batch. Frame each block so we can attribute output to its IP.
+  const script = `
+if ! command -v nmblookup >/dev/null 2>&1; then exit 0; fi
+for ip in "$@"; do
+  echo "---IP:$ip---"
+  nmblookup -A "$ip" 2>/dev/null || true
+done
+`.trim();
+
+  return server
+    .execute(new BashCommand(script, ips, superuserOpts))
+    .map((proc) => parseNmblookup(proc.getStdout(), ips))
+    .orElse(() => okAsync(empty()));
+}
+
+function parseNmblookup(stdout: string, ips: string[]): Map<string, string | null> {
+  const out = new Map<string, string | null>();
+  for (const ip of ips) out.set(ip, null);
+  if (!stdout.trim()) return out;
+
+  const blocks = stdout.split(/^---IP:([^-]+)---$/m);
+  // [pre, ip1, block1, ip2, block2, ...]
+  for (let i = 1; i < blocks.length; i += 2) {
+    const ip = blocks[i]?.trim();
+    const body = blocks[i + 1] ?? "";
+    if (!ip) continue;
+    // Look for a line like `\tQUIM            <00> -         B <ACTIVE>`.
+    // Skip <GROUP> entries (workgroup names) and the "Looking up status" header.
+    for (const raw of body.split("\n")) {
+      const line = raw.trim();
+      const m = line.match(/^(\S+)\s+<00>\s+-\s+(?!<GROUP>)/);
+      if (m && m[1]) {
+        out.set(ip, m[1]);
+        break;
+      }
+    }
+  }
+  return out;
+}

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
@@ -11,7 +11,7 @@ const superuserOpts = { superuser: "try" as const };
  * both and are left as null (UI shows "—").
  *
  * Returns whatever the resolver says verbatim — if DNS returns a short name
- * (`quim`) that's what you'll get; if it returns an FQDN that's what you'll
+ * (`nas01`) that's what you'll get; if it returns an FQDN that's what you'll
  * get; NetBIOS names are always returned in their registered short form.
  */
 export function resolveHostnames(
@@ -100,7 +100,7 @@ function parseNmblookup(stdout: string, ips: string[]): Map<string, string | nul
     const ip = blocks[i]?.trim();
     const body = blocks[i + 1] ?? "";
     if (!ip) continue;
-    // Look for a line like `\tQUIM            <00> -         B <ACTIVE>`.
+    // Look for a line like `\tWORKSTATION     <00> -         B <ACTIVE>`.
     // Skip <GROUP> entries (workgroup names) and the "Looking up status" header.
     for (const raw of body.split("\n")) {
       const line = raw.trim();

--- a/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
+++ b/file-sharing/src/tabs/connected-clients/hostname-resolver.ts
@@ -89,7 +89,7 @@ done
     .orElse(() => okAsync(empty()));
 }
 
-function parseNmblookup(stdout: string, ips: string[]): Map<string, string | null> {
+export function parseNmblookup(stdout: string, ips: string[]): Map<string, string | null> {
   const out = new Map<string, string | null>();
   for (const ip of ips) out.set(ip, null);
   if (!stdout.trim()) return out;

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
@@ -1,7 +1,35 @@
 import { suite, test, expect } from "vitest";
-import { parseDump } from "./nfs-clients";
+import {
+  parseDump,
+  parseMountInfo,
+  parseExports,
+  parseStates,
+  deriveShares,
+} from "./nfs-clients";
 
 const sample = (id: string, body: string) => `---CLIENT:${id}---\n${body}`;
+
+// Realistic-ish global context fixture for the share-derivation tests below.
+// Major:minor 0:74 maps to /tank/general, 0:75 to /tank/media, 0:99 to
+// /not-exported (deliberately not in EXPORTS to exercise the negative path).
+const ctx = (extra?: { mountinfo?: string; exports?: string }) =>
+  [
+    "---MOUNTINFO---",
+    extra?.mountinfo ??
+      [
+        "26 25 0:24 / /sys rw,relatime - sysfs sysfs rw",
+        "40 25 0:74 / /tank/general rw,relatime - zfs tank/general rw",
+        "41 25 0:75 / /tank/media rw,relatime - zfs tank/media rw",
+        "42 25 0:99 / /not-exported rw,relatime - zfs tank/scratch rw",
+      ].join("\n"),
+    "---EXPORTS---",
+    extra?.exports ??
+      [
+        "# header comment",
+        "/tank/general 10.0.0.2(rw,sync,no_subtree_check)",
+        "/tank/media   10.0.0.2(rw,sync,no_subtree_check)",
+      ].join("\n"),
+  ].join("\n") + "\n";
 
 suite("nfs-clients parseDump", () => {
   test("empty input returns no rows", () => {
@@ -215,5 +243,241 @@ suite("nfs-clients parseDump", () => {
       ["---INFO---", "status: confirmed", "name: Linux NFSv4.2 host"].join("\n")
     );
     expect(parseDump(stdout)).toEqual([]);
+  });
+});
+
+suite("nfs-clients parseMountInfo", () => {
+  test("extracts major:minor → mount-path pairs", () => {
+    const map = parseMountInfo(
+      [
+        "26 25 0:24 / /sys rw,relatime - sysfs sysfs rw",
+        "40 25 0:74 / /tank/general rw,relatime - zfs tank/general rw",
+      ].join("\n")
+    );
+    expect(map.get("0:24")).toBe("/sys");
+    expect(map.get("0:74")).toBe("/tank/general");
+    expect(map.size).toBe(2);
+  });
+
+  test("ignores lines that don't have a major:minor in column 3", () => {
+    // Garbage / truncated lines must not corrupt the map.
+    const map = parseMountInfo(
+      ["bogus line", "40 25 not-a-device / /tank/general rw - zfs tank/general rw"].join("\n")
+    );
+    expect(map.size).toBe(0);
+  });
+
+  test("empty input → empty map", () => {
+    expect(parseMountInfo("").size).toBe(0);
+  });
+});
+
+suite("nfs-clients parseExports", () => {
+  test("extracts the first whitespace-delimited path on each non-comment line", () => {
+    const set = parseExports(
+      [
+        "# comment",
+        "",
+        "/tank/general 10.0.0.2(rw,sync)",
+        "/tank/media   10.0.0.2(rw,sync,no_subtree_check)",
+      ].join("\n")
+    );
+    expect(set.has("/tank/general")).toBe(true);
+    expect(set.has("/tank/media")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  test("skips comment and blank lines", () => {
+    const set = parseExports(["# foo", "", "  ", "# /tank/should-not-appear"].join("\n"));
+    expect(set.size).toBe(0);
+  });
+
+  test("requires path to start with /", () => {
+    // wildcard / netgroup paths aren't valid NFSv4 exports; filter them out
+    // so they can't accidentally match a mount path in the derivation step.
+    const set = parseExports(["* 10.0.0.2(rw)", "@group 10.0.0.2(rw)"].join("\n"));
+    expect(set.size).toBe(0);
+  });
+});
+
+suite("nfs-clients parseStates", () => {
+  test("extracts filename + superblock and converts hex major:minor to decimal", () => {
+    // Real kernel format: superblock is hex major:minor:inode; we only need
+    // major:minor for the mountinfo join, and we want it as decimal because
+    // that's how /proc/self/mountinfo writes column 3.
+    const line =
+      `- 0x1234: { type: open, access: rw, deny: --, superblock: "00:4a:1260", ` +
+      `filename: "Wordlists/101.txt" }`;
+    const entries = parseStates(line);
+    expect(entries).toEqual([{ filename: "Wordlists/101.txt", superblock: "0:74" }]);
+  });
+
+  test("multiple entries on consecutive lines all parse", () => {
+    const content = [
+      `- 0xa: { type: deleg, access: r, superblock: "00:4a:1260", filename: "a.txt" }`,
+      `- 0xb: { type: open, access: rw, deny: --, superblock: "00:4b:99", filename: "sub/b.txt" }`,
+    ].join("\n");
+    const entries = parseStates(content);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.superblock).toBe("0:74");
+    expect(entries[1]!.superblock).toBe("0:75");
+  });
+
+  test("lines without both superblock and filename are skipped", () => {
+    expect(parseStates(`- 0x1: { type: open, superblock: "00:4a:1260" }`)).toEqual([]);
+    expect(parseStates(`- 0x1: { type: open, filename: "x" }`)).toEqual([]);
+    expect(parseStates(`random noise`)).toEqual([]);
+  });
+});
+
+suite("nfs-clients deriveShares", () => {
+  const mountInfo = new Map([
+    ["0:74", "/tank/general"],
+    ["0:75", "/tank/media"],
+    ["0:99", "/not-exported"],
+  ]);
+  const exports = new Set(["/tank/general", "/tank/media"]);
+
+  test("returns single export when one open file matches", () => {
+    expect(
+      deriveShares([{ filename: "Wordlists/101.txt", superblock: "0:74" }], mountInfo, exports)
+    ).toBe("/tank/general");
+  });
+
+  test("comma-joins (sorted) when files span multiple exports", () => {
+    expect(
+      deriveShares(
+        [
+          { filename: "a.txt", superblock: "0:75" },
+          { filename: "b.txt", superblock: "0:74" },
+        ],
+        mountInfo,
+        exports
+      )
+    ).toBe("/tank/general, /tank/media");
+  });
+
+  test("dedupes when multiple files map to the same export", () => {
+    expect(
+      deriveShares(
+        [
+          { filename: "a.txt", superblock: "0:74" },
+          { filename: "b.txt", superblock: "0:74" },
+        ],
+        mountInfo,
+        exports
+      )
+    ).toBe("/tank/general");
+  });
+
+  test("returns null when no open files", () => {
+    expect(deriveShares([], mountInfo, exports)).toBeNull();
+  });
+
+  test("returns null when superblock has no mount-info match", () => {
+    expect(
+      deriveShares([{ filename: "x", superblock: "9:99" }], mountInfo, exports)
+    ).toBeNull();
+  });
+
+  test("returns null when mount path isn't an export", () => {
+    expect(
+      deriveShares([{ filename: "x", superblock: "0:99" }], mountInfo, exports)
+    ).toBeNull();
+  });
+
+  test("returns null when exports set is empty (no /etc/exports content)", () => {
+    expect(
+      deriveShares([{ filename: "x", superblock: "0:74" }], mountInfo, new Set())
+    ).toBeNull();
+  });
+});
+
+suite("nfs-clients parseDump — share derivation integration", () => {
+  test("idle client (empty states) leaves share null", () => {
+    const stdout =
+      ctx() +
+      sample(
+        "idle",
+        [
+          "---MTIME---",
+          "1716196800",
+          "---INFO---",
+          'address: "10.0.0.2:111"',
+          'name: "Linux NFSv4.2 idleclient"',
+          "minor version: 2",
+        ].join("\n")
+      );
+    const row = parseDump(stdout)[0]!;
+    expect(row.share).toBeNull();
+    expect(row.ip).toBe("10.0.0.2");
+  });
+
+  test("active client (open file on exported mount) gets share populated", () => {
+    const stdout =
+      ctx() +
+      sample(
+        "active",
+        [
+          "---MTIME---",
+          "1716196800",
+          "---INFO---",
+          'address: "10.0.0.2:222"',
+          'name: "Linux NFSv4.2 activeclient"',
+          "minor version: 2",
+          "---STATES---",
+          `- 0x1: { type: open, superblock: "00:4a:1260", filename: "foo.txt" }`,
+        ].join("\n")
+      );
+    const row = parseDump(stdout)[0]!;
+    expect(row.share).toBe("/tank/general");
+  });
+
+  test("global context applies to every CLIENT in the dump", () => {
+    const stdout =
+      ctx() +
+      sample(
+        "c1",
+        [
+          "---INFO---",
+          'address: "10.0.0.2:1"',
+          "minor version: 2",
+          "---STATES---",
+          `- 0x1: { type: open, superblock: "00:4a:1", filename: "x" }`,
+        ].join("\n")
+      ) +
+      "\n" +
+      sample(
+        "c2",
+        [
+          "---INFO---",
+          'address: "10.0.0.3:1"',
+          "minor version: 2",
+          "---STATES---",
+          `- 0x1: { type: open, superblock: "00:4b:1", filename: "y" }`,
+        ].join("\n")
+      );
+    const rows = parseDump(stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.share).toBe("/tank/general");
+    expect(rows[1]!.share).toBe("/tank/media");
+  });
+
+  test("missing MOUNTINFO/EXPORTS context degrades gracefully (share=null, row still appears)", () => {
+    // If the bash dump emits CLIENT blocks but no global context (unlikely
+    // but defensive), every NFS row gets share=null instead of crashing.
+    const stdout = sample(
+      "abc",
+      [
+        "---INFO---",
+        'address: "10.0.0.2:1"',
+        "minor version: 2",
+        "---STATES---",
+        `- 0x1: { type: open, superblock: "00:4a:1", filename: "x" }`,
+      ].join("\n")
+    );
+    const row = parseDump(stdout)[0]!;
+    expect(row.share).toBeNull();
+    expect(row.ip).toBe("10.0.0.2");
   });
 });

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
@@ -116,4 +116,85 @@ suite("nfs-clients parseDump", () => {
     );
     expect(parseDump(stdout)[0]!.openFiles).toBe(0);
   });
+
+  test("quote-wrapped info values are stripped (real kernel format)", () => {
+    // Recent kernels wrap address and name in double quotes. The parser
+    // should strip them so the IP doesn't render as `"10.0.0.1` and the
+    // hostname as `host"`.
+    const stdout = sample(
+      "q",
+      [
+        "---INFO---",
+        'address: "10.0.0.1:919"',
+        "status: confirmed",
+        'name: "Linux NFSv4.2 quotedhost"',
+        "minor version: 2",
+      ].join("\n")
+    );
+    const row = parseDump(stdout)[0]!;
+    expect(row.ip).toBe("10.0.0.1");
+    expect(row.hostname).toBe("quotedhost");
+  });
+
+  test("MTIME marker is parsed into connectedSince", () => {
+    const epoch = 1716196800; // 2024-05-20T08:00:00Z
+    const stdout = sample(
+      "m",
+      [
+        "---MTIME---",
+        String(epoch),
+        "---INFO---",
+        "address: 10.0.0.1:919",
+        "name: Linux NFSv4.2 mtimehost",
+        "minor version: 2",
+      ].join("\n")
+    );
+    const row = parseDump(stdout)[0]!;
+    expect(row.connectedSince).toBeInstanceOf(Date);
+    expect(row.connectedSince!.getTime()).toBe(epoch * 1000);
+  });
+
+  test("missing MTIME marker leaves connectedSince null", () => {
+    // Older kernels / hosts where stat -c %Y produced no output; parser
+    // must fall back to null rather than NaN-ing the Date.
+    const stdout = sample(
+      "n",
+      ["---INFO---", "address: 10.0.0.1:919", "name: Linux NFSv4.2 host", "minor version: 2"].join(
+        "\n"
+      )
+    );
+    expect(parseDump(stdout)[0]!.connectedSince).toBeNull();
+  });
+
+  test("non-numeric MTIME line yields null connectedSince", () => {
+    const stdout = sample(
+      "b",
+      [
+        "---MTIME---",
+        "not-an-epoch",
+        "---INFO---",
+        "address: 10.0.0.1:919",
+        "name: Linux NFSv4.2 host",
+        "minor version: 2",
+      ].join("\n")
+    );
+    expect(parseDump(stdout)[0]!.connectedSince).toBeNull();
+  });
+
+  test("MTIME of 0 (epoch) is rejected as connectedSince", () => {
+    // A real client dentry will always have a positive mtime; 0 indicates
+    // stat failed or returned a placeholder. Treat as missing.
+    const stdout = sample(
+      "z",
+      [
+        "---MTIME---",
+        "0",
+        "---INFO---",
+        "address: 10.0.0.1:919",
+        "name: Linux NFSv4.2 host",
+        "minor version: 2",
+      ].join("\n")
+    );
+    expect(parseDump(stdout)[0]!.connectedSince).toBeNull();
+  });
 });

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
@@ -197,4 +197,23 @@ suite("nfs-clients parseDump", () => {
     );
     expect(parseDump(stdout)[0]!.connectedSince).toBeNull();
   });
+
+  test("CLIENT block with no parseable address produces no row", () => {
+    // Regression: when /proc/fs/nfsd/clients/ exists but is empty, the bash
+    // glob doesn't expand and the dump produced a stray `---CLIENT:*---`
+    // with no INFO content. The parser must skip it, not emit a phantom row
+    // with id "nfs:*" and empty IP.
+    const stdout = sample("*", "---MTIME---\n");
+    expect(parseDump(stdout)).toEqual([]);
+  });
+
+  test("CLIENT block with INFO but no address is also skipped", () => {
+    // Belt-and-braces: even if a future kernel format omitted the address
+    // line, we shouldn't render a row with no identity.
+    const stdout = sample(
+      "abc",
+      ["---INFO---", "status: confirmed", "name: Linux NFSv4.2 host"].join("\n")
+    );
+    expect(parseDump(stdout)).toEqual([]);
+  });
 });

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
@@ -1,0 +1,119 @@
+import { suite, test, expect } from "vitest";
+import { parseDump } from "./nfs-clients";
+
+const sample = (id: string, body: string) => `---CLIENT:${id}---\n${body}`;
+
+suite("nfs-clients parseDump", () => {
+  test("empty input returns no rows", () => {
+    expect(parseDump("")).toEqual([]);
+    expect(parseDump("   \n  \n")).toEqual([]);
+  });
+
+  test("single client with full info block", () => {
+    const stdout = sample(
+      "abc123",
+      [
+        "---INFO---",
+        "address: 192.168.3.8:919",
+        "status: confirmed",
+        "name: Linux NFSv4.2 quim",
+        "minor version: 2",
+        "Implementation domain: kernel.org",
+        "callback state: UP",
+        "---STATES---",
+        "type: O, # locks: 0, # files: 1, stateid: foo",
+      ].join("\n")
+    );
+    const rows = parseDump(stdout);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "nfs:abc123",
+      protocol: "nfs",
+      user: null,
+      ip: "192.168.3.8",
+      hostname: "quim",
+      protocolVersion: "NFSv4.2",
+      share: null,
+      connectedSince: null,
+      openFiles: 1,
+      encrypted: false,
+    });
+  });
+
+  test("multiple clients are returned in order", () => {
+    const stdout =
+      sample(
+        "a",
+        ["---INFO---", "address: 10.0.0.1:919", "name: Linux NFSv4.1 host-a", "minor version: 1"].join(
+          "\n"
+        )
+      ) +
+      "\n" +
+      sample(
+        "b",
+        ["---INFO---", "address: 10.0.0.2:919", "name: Linux NFSv4.2 host-b", "minor version: 2"].join(
+          "\n"
+        )
+      );
+    const rows = parseDump(stdout);
+    expect(rows.map((r) => r.id)).toEqual(["nfs:a", "nfs:b"]);
+    expect(rows.map((r) => r.protocolVersion)).toEqual(["NFSv4.1", "NFSv4.2"]);
+    expect(rows.map((r) => r.hostname)).toEqual(["host-a", "host-b"]);
+  });
+
+  test("IPv6 address has the bracketed part extracted as ip", () => {
+    const stdout = sample(
+      "v6",
+      ["---INFO---", "address: [fe80::1]:919", "name: Linux NFSv4.2 ipv6host", "minor version: 2"].join(
+        "\n"
+      )
+    );
+    const rows = parseDump(stdout);
+    expect(rows[0]!.ip).toBe("fe80::1");
+  });
+
+  test("name with no trailing hostname leaves hostname null", () => {
+    const stdout = sample(
+      "x",
+      ["---INFO---", "address: 10.0.0.1:919", "name: Linux", "minor version: 2"].join("\n")
+    );
+    expect(parseDump(stdout)[0]!.hostname).toBeNull();
+  });
+
+  test("missing minor version falls back to NFSv4", () => {
+    const stdout = sample(
+      "x",
+      ["---INFO---", "address: 10.0.0.1:919", "name: Something else here"].join("\n")
+    );
+    expect(parseDump(stdout)[0]!.protocolVersion).toBe("NFSv4");
+  });
+
+  test("states block: count is non-empty trimmed lines", () => {
+    const stdout = sample(
+      "x",
+      [
+        "---INFO---",
+        "address: 10.0.0.1:919",
+        "name: Linux NFSv4.2 client",
+        "minor version: 2",
+        "---STATES---",
+        "  line1  ",
+        "",
+        "line2",
+        "",
+        "line3",
+      ].join("\n")
+    );
+    expect(parseDump(stdout)[0]!.openFiles).toBe(3);
+  });
+
+  test("no states block yields openFiles 0", () => {
+    const stdout = sample(
+      "x",
+      ["---INFO---", "address: 10.0.0.1:919", "name: Linux NFSv4.2 client", "minor version: 2"].join(
+        "\n"
+      )
+    );
+    expect(parseDump(stdout)[0]!.openFiles).toBe(0);
+  });
+});

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.test.ts
@@ -254,9 +254,25 @@ suite("nfs-clients parseMountInfo", () => {
         "40 25 0:74 / /tank/general rw,relatime - zfs tank/general rw",
       ].join("\n")
     );
-    expect(map.get("0:24")).toBe("/sys");
-    expect(map.get("0:74")).toBe("/tank/general");
+    expect(map.get("0:24")).toEqual(["/sys"]);
+    expect(map.get("0:74")).toEqual(["/tank/general"]);
     expect(map.size).toBe(2);
+  });
+
+  test("collects ALL mount paths for the same superblock (multi-mount filesystems)", () => {
+    // A single filesystem can be visible at multiple mount points — bind
+    // mounts, ZFS datasets with secondary mountpoints, LVM-bind layouts,
+    // some container setups. Keeping every candidate lets deriveShares pick
+    // whichever one is actually exported, regardless of mountinfo line
+    // order (which a single-value Map would silently truncate to "last
+    // wins" — and "last" can easily be a non-exported bind-mount path).
+    const map = parseMountInfo(
+      [
+        "40 25 0:42 / /srv/data rw - ext4 /dev/sda1 rw",
+        "41 25 0:42 / /export/data rw - ext4 /dev/sda1 rw",
+      ].join("\n")
+    );
+    expect(map.get("0:42")).toEqual(["/srv/data", "/export/data"]);
   });
 
   test("ignores lines that don't have a major:minor in column 3", () => {
@@ -331,10 +347,10 @@ suite("nfs-clients parseStates", () => {
 });
 
 suite("nfs-clients deriveShares", () => {
-  const mountInfo = new Map([
-    ["0:74", "/tank/general"],
-    ["0:75", "/tank/media"],
-    ["0:99", "/not-exported"],
+  const mountInfo = new Map<string, string[]>([
+    ["0:74", ["/tank/general"]],
+    ["0:75", ["/tank/media"]],
+    ["0:99", ["/not-exported"]],
   ]);
   const exports = new Set(["/tank/general", "/tank/media"]);
 
@@ -390,6 +406,22 @@ suite("nfs-clients deriveShares", () => {
     expect(
       deriveShares([{ filename: "x", superblock: "0:74" }], mountInfo, new Set())
     ).toBeNull();
+  });
+
+  test("multi-mount filesystem: picks the export-matching path, ignores siblings", () => {
+    // Regression: when a filesystem is visible at multiple mount points (e.g.
+    // a ZFS dataset with a secondary mountpoint, or any `mount --bind`
+    // layout), the parser keeps every candidate path and deriveShares picks
+    // whichever is the actual export — regardless of mountinfo line order.
+    // Before the fix this collapsed to a single value, last-write-wins, and
+    // a non-exported bind-mount path would silently win.
+    const multiMount = new Map<string, string[]>([
+      ["0:42", ["/srv/data", "/export/data", "/mnt/bind/data"]],
+    ]);
+    const onlyExportedPath = new Set(["/export/data"]);
+    expect(
+      deriveShares([{ filename: "f", superblock: "0:42" }], multiMount, onlyExportedPath)
+    ).toBe("/export/data");
   });
 });
 

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -12,6 +12,11 @@ const superuserOpts = { superuser: "try" as const };
  * Bash payload that dumps every /proc/fs/nfsd/clients/<id>/{info,states} in a
  * single round-trip, framed by markers we parse below. We accept that this is
  * NFSv4-only: v3 clients have no kernel-side client identity.
+ *
+ * Requires the kernel's NFSv4 client tracking interface, available on Linux
+ * 5.3+. On older kernels (or hosts not running the NFS server) the directory
+ * is absent and this script exits cleanly with empty stdout — the UI then
+ * shows no NFS rows, which is the correct outcome.
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -28,6 +28,16 @@ const superuserOpts = { superuser: "try" as const };
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
+# Global context for share derivation (see deriveShares). Emitted once at the
+# top of the dump so it lives outside any CLIENT block. The MOUNTINFO maps a
+# superblock id (from the states file) back to a mount point; EXPORTS lists
+# the server's exported paths. Per-client states entries reference files by
+# (superblock, relative path) — joining these three lets us name the export(s)
+# a client is actively using.
+echo "---MOUNTINFO---"
+cat /proc/self/mountinfo 2>/dev/null
+echo "---EXPORTS---"
+cat /etc/exports /etc/exports.d/*.exports 2>/dev/null
 for d in /proc/fs/nfsd/clients/*/; do
   # When the directory exists but is empty, bash's default glob behavior keeps
   # the literal pattern, so $d would be ".../clients/*/" and basename would
@@ -107,12 +117,109 @@ function countStates(block: string): number {
     .filter((l) => l.length > 0).length;
 }
 
+/**
+ * Parse /proc/self/mountinfo into a map from "major:minor" (decimal, as
+ * mountinfo writes it) to the mount point path. We use the kernel's own
+ * device numbering as the join key for matching states-file entries below.
+ */
+function parseMountInfo(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const parts = raw.trim().split(/\s+/);
+    if (parts.length < 5) continue;
+    const majorMinor = parts[2];
+    const mountPath = parts[4];
+    if (majorMinor && mountPath && /^\d+:\d+$/.test(majorMinor)) {
+      map.set(majorMinor, mountPath);
+    }
+  }
+  return map;
+}
+
+/**
+ * Parse one-or-more /etc/exports-style files into a set of exported paths.
+ * Skips comment and blank lines; first whitespace-delimited token on each
+ * remaining line is the export path. Wildcard / netgroup paths aren't
+ * supported by NFSv4 anyway, so a strict starts-with-"/" filter is enough.
+ */
+function parseExports(content: string): Set<string> {
+  const set = new Set<string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const path = line.split(/\s+/)[0];
+    if (path && path.startsWith("/")) set.add(path);
+  }
+  return set;
+}
+
+interface ParsedStateEntry {
+  filename: string;
+  /** "major:minor" in decimal, normalized to match parseMountInfo output. */
+  superblock: string;
+}
+
+/**
+ * Extract (filename, superblock) tuples from a client's states file. Each
+ * entry looks like:
+ *   - 0x<hex>: { type: open, ..., superblock: "00:4a:1260", filename: "foo/bar" }
+ * The superblock value is hex `major:minor:inode`; we drop the inode and
+ * convert major:minor to decimal so it joins against mountinfo's format.
+ */
+function parseStates(content: string): ParsedStateEntry[] {
+  const entries: ParsedStateEntry[] = [];
+  for (const line of content.split("\n")) {
+    const superMatch = line.match(/superblock:\s*"([0-9a-fA-F]+):([0-9a-fA-F]+):[0-9a-fA-F]+"/);
+    const fileMatch = line.match(/filename:\s*"([^"]*)"/);
+    if (!superMatch || !fileMatch) continue;
+    const majHex = superMatch[1];
+    const minHex = superMatch[2];
+    const filename = fileMatch[1];
+    if (!majHex || !minHex || filename === undefined) continue;
+    const decimal = `${parseInt(majHex, 16)}:${parseInt(minHex, 16)}`;
+    entries.push({ filename, superblock: decimal });
+  }
+  return entries;
+}
+
+/**
+ * Derive a comma-joined list of exports a client is *actively using*, by
+ * mapping each open file's superblock back to a mount path and then to a
+ * matching export. The Samba `Share` column reflects "mounted shares"
+ * because tcons are stateful per-share; NFSv4 has no such concept, so this
+ * column only populates while files are actively open. An idle-but-mounted
+ * client will show null here. The UI surfaces a tooltip to make this
+ * limitation discoverable.
+ */
+function deriveShares(
+  statesEntries: ParsedStateEntry[],
+  mountInfo: Map<string, string>,
+  exports: Set<string>
+): string | null {
+  if (statesEntries.length === 0 || exports.size === 0) return null;
+  const shares = new Set<string>();
+  for (const e of statesEntries) {
+    const mountPath = mountInfo.get(e.superblock);
+    if (mountPath && exports.has(mountPath)) shares.add(mountPath);
+  }
+  if (shares.size === 0) return null;
+  return [...shares].sort().join(", ");
+}
+
 function parseDump(stdout: string): ConnectedClient[] {
   const out: ConnectedClient[] = [];
   if (!stdout.trim()) return out;
 
   const clientBlocks = stdout.split(/^---CLIENT:([^-]+)---$/m);
-  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...]
+  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...].
+  // The "pre" slot (clientBlocks[0]) holds the global context (MOUNTINFO +
+  // EXPORTS) emitted before any client block.
+  const globalContext = clientBlocks[0] ?? "";
+  const mountInfoMatch = globalContext.match(/---MOUNTINFO---\n([\s\S]*?)(?=---EXPORTS---|$)/);
+  const exportsMatch = globalContext.match(/---EXPORTS---\n([\s\S]*?)$/);
+  const mountInfo = parseMountInfo(mountInfoMatch?.[1] ?? "");
+  const exports = parseExports(exportsMatch?.[1] ?? "");
+
   for (let i = 1; i < clientBlocks.length; i += 2) {
     const id = clientBlocks[i]?.trim();
     const body = clientBlocks[i + 1] ?? "";
@@ -123,8 +230,10 @@ function parseDump(stdout: string): ConnectedClient[] {
     const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
 
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
-    const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+    const statesContent = statesMatch?.[1] ?? "";
+    const openFiles = statesMatch ? countStates(statesContent) : 0;
     const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
+    const share = deriveShares(parseStates(statesContent), mountInfo, exports);
 
     // Defensive: skip blocks with no parseable address. The bash dump shouldn't
     // produce these (it filters non-directories), but a CLIENT marker with an
@@ -139,7 +248,7 @@ function parseDump(stdout: string): ConnectedClient[] {
       ip: parsed.address,
       hostname: parsed.hostname,
       protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
-      share: null,
+      share,
       connectedSince,
       openFiles,
       encrypted: false,

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -1,0 +1,121 @@
+import {
+  BashCommand,
+  ProcessError,
+  Server,
+} from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+
+const superuserOpts = { superuser: "try" as const };
+
+/**
+ * Bash payload that dumps every /proc/fs/nfsd/clients/<id>/{info,states} in a
+ * single round-trip, framed by markers we parse below. We accept that this is
+ * NFSv4-only: v3 clients have no kernel-side client identity.
+ */
+const dumpScript = `
+if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
+for d in /proc/fs/nfsd/clients/*/; do
+  id=$(basename "$d")
+  echo "---CLIENT:$id---"
+  if [ -r "$d/info" ]; then
+    echo "---INFO---"
+    cat "$d/info" 2>/dev/null
+  fi
+  if [ -r "$d/states" ]; then
+    echo "---STATES---"
+    cat "$d/states" 2>/dev/null
+  fi
+done
+`.trim();
+
+interface ParsedInfo {
+  address: string;
+  hostname: string | null;
+  minorVersion: string | null;
+  status: string | null;
+}
+
+function parseInfoBlock(block: string): ParsedInfo {
+  const info: Record<string, string> = {};
+  for (const raw of block.split("\n")) {
+    const line = raw.trim();
+    if (!line || !line.includes(":")) continue;
+    const idx = line.indexOf(":");
+    const k = line.slice(0, idx).trim();
+    const v = line.slice(idx + 1).trim();
+    info[k] = v;
+  }
+  // address looks like "192.168.1.10:919" or "[fe80::1]:919"
+  const rawAddr = info["address"] ?? "";
+  let address = rawAddr;
+  const ipv6 = rawAddr.match(/^\[([^\]]+)\]/);
+  if (ipv6) {
+    address = ipv6[1] ?? rawAddr;
+  } else if (rawAddr.includes(":")) {
+    address = rawAddr.split(":")[0] ?? rawAddr;
+  }
+  // name looks like "Linux NFSv4.2 hostname" — last whitespace-delimited token
+  // is usually the client hostname. Treat absence gracefully.
+  let hostname: string | null = null;
+  const name = info["name"];
+  if (name) {
+    const parts = name.split(/\s+/);
+    hostname = parts.length > 2 ? (parts[parts.length - 1] ?? null) : null;
+  }
+  return {
+    address,
+    hostname,
+    minorVersion: info["minor version"] ?? null,
+    status: info["status"] ?? null,
+  };
+}
+
+function countStates(block: string): number {
+  // The `states` file is one stateid per line (opens + locks + delegations).
+  // A rough "active opens" count is fine here; this is just a UI hint.
+  return block
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0).length;
+}
+
+function parseDump(stdout: string): ConnectedClient[] {
+  const out: ConnectedClient[] = [];
+  if (!stdout.trim()) return out;
+
+  const clientBlocks = stdout.split(/^---CLIENT:([^-]+)---$/m);
+  // split() with a capturing group yields: [pre, id1, block1, id2, block2, ...]
+  for (let i = 1; i < clientBlocks.length; i += 2) {
+    const id = clientBlocks[i]?.trim();
+    const body = clientBlocks[i + 1] ?? "";
+    if (!id) continue;
+
+    const infoMatch = body.match(/---INFO---\n([\s\S]*?)(?=---STATES---|$)/);
+    const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
+
+    const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
+    const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+
+    out.push({
+      id: `nfs:${id}`,
+      protocol: "nfs",
+      user: null,
+      ip: parsed.address,
+      hostname: parsed.hostname,
+      protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
+      share: null,
+      connectedSince: null,
+      openFiles,
+      encrypted: false,
+    });
+  }
+  return out;
+}
+
+export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  return server
+    .execute(new BashCommand(dumpScript, [], superuserOpts))
+    .map((proc) => parseDump(proc.getStdout()))
+    .orElse(() => okAsync([] as ConnectedClient[]));
+}

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -23,6 +23,11 @@ if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
 for d in /proc/fs/nfsd/clients/*/; do
   id=$(basename "$d")
   echo "---CLIENT:$id---"
+  # mtime of the client dentry = first-contact time. The kernel creates the
+  # dentry when a client confirms and only recreates it on lease expiry +
+  # reconnect, so this stays put across NFSv4 lease renewals.
+  echo "---MTIME---"
+  stat -c %Y "$d" 2>/dev/null
   if [ -r "$d/info" ]; then
     echo "---INFO---"
     cat "$d/info" 2>/dev/null
@@ -48,7 +53,12 @@ function parseInfoBlock(block: string): ParsedInfo {
     if (!line || !line.includes(":")) continue;
     const idx = line.indexOf(":");
     const k = line.slice(0, idx).trim();
-    const v = line.slice(idx + 1).trim();
+    let v = line.slice(idx + 1).trim();
+    // Recent kernels wrap values in double quotes (e.g. `address: "10.0.0.1:919"`,
+    // `name: "Linux NFSv4.2 host"`); older ones don't. Strip them defensively.
+    if (v.length >= 2 && v.startsWith('"') && v.endsWith('"')) {
+      v = v.slice(1, -1);
+    }
     info[k] = v;
   }
   // address looks like "192.168.1.10:919" or "[fe80::1]:919"
@@ -96,11 +106,13 @@ function parseDump(stdout: string): ConnectedClient[] {
     const body = clientBlocks[i + 1] ?? "";
     if (!id) continue;
 
+    const mtimeMatch = body.match(/---MTIME---\n([^\n]*)/);
     const infoMatch = body.match(/---INFO---\n([\s\S]*?)(?=---STATES---|$)/);
     const statesMatch = body.match(/---STATES---\n([\s\S]*)$/);
 
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
     const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
+    const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
 
     out.push({
       id: `nfs:${id}`,
@@ -110,12 +122,18 @@ function parseDump(stdout: string): ConnectedClient[] {
       hostname: parsed.hostname,
       protocolVersion: parsed.minorVersion ? `NFSv4.${parsed.minorVersion}` : "NFSv4",
       share: null,
-      connectedSince: null,
+      connectedSince,
       openFiles,
       encrypted: false,
     });
   }
   return out;
+}
+
+function parseMtime(s: string): Date | null {
+  const epoch = Number.parseInt(s.trim(), 10);
+  if (!Number.isFinite(epoch) || epoch <= 0) return null;
+  return new Date(epoch * 1000);
 }
 
 export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -3,7 +3,7 @@ import {
   ProcessError,
   Server,
 } from "@45drives/houston-common-lib";
-import { ResultAsync, okAsync } from "neverthrow";
+import { ResultAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 
 const superuserOpts = { superuser: "try" as const };
@@ -114,8 +114,10 @@ function parseDump(stdout: string): ConnectedClient[] {
 }
 
 export function getNfsClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  // The dump script itself handles "directory not present" (NFSv4 server not
+  // running) by exiting cleanly with empty stdout. Any other failure is real
+  // and should propagate so the UI can surface it.
   return server
     .execute(new BashCommand(dumpScript, [], superuserOpts))
-    .map((proc) => parseDump(proc.getStdout()))
-    .orElse(() => okAsync([] as ConnectedClient[]));
+    .map((proc) => parseDump(proc.getStdout()));
 }

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -119,18 +119,22 @@ function countStates(block: string): number {
 
 /**
  * Parse /proc/self/mountinfo into a map from "major:minor" (decimal, as
- * mountinfo writes it) to the mount point path. We use the kernel's own
- * device numbering as the join key for matching states-file entries below.
+ * mountinfo writes it) to the list of mount paths that share that device.
+ * Multi-value because a single filesystem can be mounted at multiple paths
+ * (e.g. ZFS dataset + bind mounts of it); we need to keep all candidates so
+ * deriveShares can pick the one that's actually an NFS export.
  */
-function parseMountInfo(content: string): Map<string, string> {
-  const map = new Map<string, string>();
+export function parseMountInfo(content: string): Map<string, string[]> {
+  const map = new Map<string, string[]>();
   for (const raw of content.split("\n")) {
     const parts = raw.trim().split(/\s+/);
     if (parts.length < 5) continue;
     const majorMinor = parts[2];
     const mountPath = parts[4];
     if (majorMinor && mountPath && /^\d+:\d+$/.test(majorMinor)) {
-      map.set(majorMinor, mountPath);
+      const existing = map.get(majorMinor);
+      if (existing) existing.push(mountPath);
+      else map.set(majorMinor, [mountPath]);
     }
   }
   return map;
@@ -142,7 +146,7 @@ function parseMountInfo(content: string): Map<string, string> {
  * remaining line is the export path. Wildcard / netgroup paths aren't
  * supported by NFSv4 anyway, so a strict starts-with-"/" filter is enough.
  */
-function parseExports(content: string): Set<string> {
+export function parseExports(content: string): Set<string> {
   const set = new Set<string>();
   for (const raw of content.split("\n")) {
     const line = raw.trim();
@@ -166,7 +170,7 @@ interface ParsedStateEntry {
  * The superblock value is hex `major:minor:inode`; we drop the inode and
  * convert major:minor to decimal so it joins against mountinfo's format.
  */
-function parseStates(content: string): ParsedStateEntry[] {
+export function parseStates(content: string): ParsedStateEntry[] {
   const entries: ParsedStateEntry[] = [];
   for (const line of content.split("\n")) {
     const superMatch = line.match(/superblock:\s*"([0-9a-fA-F]+):([0-9a-fA-F]+):[0-9a-fA-F]+"/);
@@ -191,22 +195,31 @@ function parseStates(content: string): ParsedStateEntry[] {
  * client will show null here. The UI surfaces a tooltip to make this
  * limitation discoverable.
  */
-function deriveShares(
+export function deriveShares(
   statesEntries: ParsedStateEntry[],
-  mountInfo: Map<string, string>,
+  mountInfo: Map<string, string[]>,
   exports: Set<string>
 ): string | null {
   if (statesEntries.length === 0 || exports.size === 0) return null;
   const shares = new Set<string>();
   for (const e of statesEntries) {
-    const mountPath = mountInfo.get(e.superblock);
-    if (mountPath && exports.has(mountPath)) shares.add(mountPath);
+    const candidates = mountInfo.get(e.superblock);
+    if (!candidates) continue;
+    // A single filesystem can have multiple mount paths (ZFS dataset + bind
+    // mounts, for example); find one that's actually exported. First match
+    // wins — they all reference the same underlying storage.
+    for (const path of candidates) {
+      if (exports.has(path)) {
+        shares.add(path);
+        break;
+      }
+    }
   }
   if (shares.size === 0) return null;
   return [...shares].sort().join(", ");
 }
 
-function parseDump(stdout: string): ConnectedClient[] {
+export function parseDump(stdout: string): ConnectedClient[] {
   const out: ConnectedClient[] = [];
   if (!stdout.trim()) return out;
 

--- a/file-sharing/src/tabs/connected-clients/nfs-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/nfs-clients.ts
@@ -17,10 +17,22 @@ const superuserOpts = { superuser: "try" as const };
  * 5.3+. On older kernels (or hosts not running the NFS server) the directory
  * is absent and this script exits cleanly with empty stdout — the UI then
  * shows no NFS rows, which is the correct outcome.
+ *
+ * NFSv4 lease semantics: the kernel only keeps a client entry while the
+ * client has an active lease (~90s since the last operation by default).
+ * An idle mount whose lease has lapsed will not appear here until the next
+ * I/O re-confirms it — any touch of the mount (`ls`, `stat`, file open)
+ * re-establishes the lease and the entry reappears. Operators should
+ * expect NFS rows to rotate in and out over time; that's the kernel's
+ * notion of "connected", not a bug in this view.
  */
 const dumpScript = `
 if [ ! -d /proc/fs/nfsd/clients ]; then exit 0; fi
 for d in /proc/fs/nfsd/clients/*/; do
+  # When the directory exists but is empty, bash's default glob behavior keeps
+  # the literal pattern, so $d would be ".../clients/*/" and basename would
+  # give "*". Skip non-directories defensively (no nullglob assumption).
+  [ -d "$d" ] || continue
   id=$(basename "$d")
   echo "---CLIENT:$id---"
   # mtime of the client dentry = first-contact time. The kernel creates the
@@ -113,6 +125,12 @@ function parseDump(stdout: string): ConnectedClient[] {
     const parsed = parseInfoBlock(infoMatch?.[1] ?? "");
     const openFiles = statesMatch ? countStates(statesMatch[1] ?? "") : 0;
     const connectedSince = parseMtime(mtimeMatch?.[1] ?? "");
+
+    // Defensive: skip blocks with no parseable address. The bash dump shouldn't
+    // produce these (it filters non-directories), but a CLIENT marker with an
+    // empty info block would otherwise render as a phantom row with id "nfs:*"
+    // and empty IP/hostname. Easier to guarantee correctness here too.
+    if (!parsed.address) continue;
 
     out.push({
       id: `nfs:${id}`,

--- a/file-sharing/src/tabs/connected-clients/samba-clients.test.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.test.ts
@@ -1,0 +1,171 @@
+import { suite, test, expect } from "vitest";
+import { buildClients } from "./samba-clients";
+
+suite("samba-clients buildClients", () => {
+  test("empty smbstatus output returns no rows", () => {
+    expect(buildClients({})).toEqual([]);
+    expect(buildClients({ sessions: {}, tcons: {}, open_files: {} })).toEqual([]);
+  });
+
+  test("single session with single tcon yields one row", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": {
+          session_id: "111",
+          username: "alice",
+          remote_machine: "10.0.0.1",
+          hostname: "ipv4:10.0.0.1:1234",
+          session_dialect: "SMB3_11",
+          auth_time: "2026-01-01T00:00:00+00:00",
+          encryption: { cipher: "AES-128-GCM", degree: "full" },
+        },
+      },
+      tcons: {
+        "222": {
+          tcon_id: "222",
+          session_id: "111",
+          service: "Public",
+          machine: "10.0.0.1",
+          connected_at: "2026-01-01T00:00:05+00:00",
+          encryption: { cipher: "AES-128-GCM", degree: "full" },
+        },
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      protocol: "samba",
+      user: "alice",
+      ip: "10.0.0.1",
+      share: "Public",
+      protocolVersion: "SMB3_11",
+      encrypted: true,
+      openFiles: 0,
+    });
+  });
+
+  test("multi-tcon session yields one row per tcon", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": {
+          session_id: "111",
+          username: "alice",
+          remote_machine: "10.0.0.1",
+          session_dialect: "SMB3_11",
+        },
+      },
+      tcons: {
+        "200": { tcon_id: "200", session_id: "111", service: "IPC$" },
+        "201": { tcon_id: "201", session_id: "111", service: "Resilio" },
+        "202": { tcon_id: "202", session_id: "111", service: "Downloads" },
+      },
+    });
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.share).sort()).toEqual(["Downloads", "IPC$", "Resilio"]);
+    expect(new Set(rows.map((r) => r.user))).toEqual(new Set(["alice"]));
+  });
+
+  test("session without a tcon still produces a row", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": {
+          session_id: "111",
+          username: "alice",
+          remote_machine: "10.0.0.1",
+          session_dialect: "SMB3_11",
+          auth_time: "2026-01-01T00:00:00+00:00",
+        },
+      },
+      tcons: {},
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      protocol: "samba",
+      user: "alice",
+      ip: "10.0.0.1",
+      share: null,
+    });
+  });
+
+  test("open_files entries count toward the matching tcon's row", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": { session_id: "111", username: "alice", remote_machine: "10.0.0.1" },
+      },
+      tcons: {
+        "222": { tcon_id: "222", session_id: "111", service: "Public" },
+        "333": { tcon_id: "333", session_id: "111", service: "Other" },
+      },
+      open_files: {
+        "0/1001": { opens: { "111/222": {}, "111/333": {} } },
+        "0/1002": { opens: { "111/222": {} } },
+      },
+    });
+    const byShare = Object.fromEntries(rows.map((r) => [r.share, r.openFiles]));
+    expect(byShare.Public).toBe(2);
+    expect(byShare.Other).toBe(1);
+  });
+
+  test("encryption: false when degree is none, true when cipher is set", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": {
+          session_id: "111",
+          username: "alice",
+          remote_machine: "10.0.0.1",
+          encryption: { cipher: "-", degree: "none" },
+        },
+      },
+      tcons: {
+        "200": {
+          tcon_id: "200",
+          session_id: "111",
+          service: "Plain",
+          encryption: { cipher: "-", degree: "none" },
+        },
+        "201": {
+          tcon_id: "201",
+          session_id: "111",
+          service: "Encrypted",
+          encryption: { cipher: "AES-128-GCM", degree: "full" },
+        },
+      },
+    });
+    const byShare = Object.fromEntries(rows.map((r) => [r.share, r.encrypted]));
+    expect(byShare.Plain).toBe(false);
+    expect(byShare.Encrypted).toBe(true);
+  });
+
+  test("connectedSince prefers tcon.connected_at over session.auth_time", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": {
+          session_id: "111",
+          username: "alice",
+          remote_machine: "10.0.0.1",
+          auth_time: "2026-01-01T00:00:00+00:00",
+        },
+      },
+      tcons: {
+        "200": {
+          tcon_id: "200",
+          session_id: "111",
+          service: "Public",
+          connected_at: "2026-01-01T00:05:00+00:00",
+        },
+      },
+    });
+    expect(rows[0]!.connectedSince?.toISOString()).toBe("2026-01-01T00:05:00.000Z");
+  });
+
+  test("row id is `samba:${sessionId}/${tconId}`", () => {
+    const rows = buildClients({
+      sessions: {
+        "111": { session_id: "111", username: "alice", remote_machine: "10.0.0.1" },
+      },
+      tcons: {
+        "200": { tcon_id: "200", session_id: "111", service: "Public" },
+      },
+    });
+    expect(rows[0]!.id).toBe("samba:111/200");
+  });
+});

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -63,7 +63,7 @@ function parseDate(s: string | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-function buildClients(status: SmbStatusJson): ConnectedClient[] {
+export function buildClients(status: SmbStatusJson): ConnectedClient[] {
   const sessions = status.sessions ?? {};
   const tcons = status.tcons ?? {};
   const openFiles = status.open_files ?? {};

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -55,6 +55,9 @@ function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
 }
 
 function parseDate(s: string | undefined): Date | null {
+  // Samba emits ISO 8601 with explicit TZ offset (e.g. "2025-04-15T15:32:46.123+00:00").
+  // new Date() parses that unambiguously; naive strings (no offset) would be interpreted
+  // as browser-local, silently producing wrong timestamps off by the browser-vs-server skew.
   if (!s) return null;
   const d = new Date(s);
   return Number.isNaN(d.getTime()) ? null : d;

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -1,9 +1,10 @@
 import {
   BashCommand,
+  ParsingError,
   ProcessError,
   Server,
 } from "@45drives/houston-common-lib";
-import { ResultAsync, okAsync } from "neverthrow";
+import { ResultAsync, err, ok, okAsync } from "neverthrow";
 import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
 
 const superuserOpts = { superuser: "try" as const };
@@ -42,17 +43,9 @@ interface SmbStatusJson {
   open_files?: Record<string, SmbOpenFile>;
 }
 
-// `hostname` field looks like "ipv4:1.2.3.4:54321" or "ipv6:[::1]:1234"; pull
-// the printable address if we have it, else fall back to remote_machine.
-function parseHostname(session: SmbSession): string | null {
-  const h = session.hostname;
-  if (!h) return null;
-  const ipv4 = h.match(/^ipv4:([^:]+):\d+$/);
-  if (ipv4) return ipv4[1] ?? null;
-  const ipv6 = h.match(/^ipv6:\[([^\]]+)\]:\d+$/);
-  if (ipv6) return ipv6[1] ?? null;
-  return null;
-}
+// smbstatus -j's `hostname` field is just the connection endpoint string
+// (e.g. "ipv4:1.2.3.4:54321") — not a real DNS name. Samba doesn't surface a
+// resolved hostname here, so leave it null and let the UI show "—".
 
 function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
   if (!enc) return false;
@@ -92,7 +85,7 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
       protocol: "samba",
       user: session.username ?? null,
       ip: session.remote_machine ?? tcon.machine ?? "",
-      hostname: parseHostname(session),
+      hostname: null,
       protocolVersion: session.session_dialect ?? "SMB",
       share: tcon.service ?? null,
       connectedSince: parseDate(tcon.connected_at) ?? parseDate(session.auth_time),
@@ -112,7 +105,7 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
       protocol: "samba",
       user: session.username ?? null,
       ip: session.remote_machine ?? "",
-      hostname: parseHostname(session),
+      hostname: null,
       protocolVersion: session.session_dialect ?? "SMB",
       share: null,
       connectedSince: parseDate(session.auth_time),
@@ -124,7 +117,9 @@ function buildClients(status: SmbStatusJson): ConnectedClient[] {
   return rows;
 }
 
-export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+export function getSambaClients(
+  server: Server
+): ResultAsync<ConnectedClient[], ProcessError | ParsingError> {
   // Empty list if smbstatus is unavailable — keeps the tab functional on NFS-only boxes.
   return server
     .execute(new BashCommand("command -v smbstatus >/dev/null 2>&1"), false)
@@ -132,14 +127,15 @@ export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], 
       if (!proc.succeeded()) return okAsync([] as ConnectedClient[]);
       return server
         .execute(new BashCommand("smbstatus -j 2>/dev/null", [], superuserOpts))
-        .map((p) => {
+        .andThen((p) => {
           const out = p.getStdout().trim();
-          if (!out) return [] as ConnectedClient[];
+          if (!out) return ok([] as ConnectedClient[]);
           try {
             const parsed = JSON.parse(out) as SmbStatusJson;
-            return buildClients(parsed);
-          } catch {
-            return [] as ConnectedClient[];
+            return ok(buildClients(parsed));
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            return err(new ParsingError(`smbstatus -j returned invalid JSON: ${msg}`));
           }
         });
     });

--- a/file-sharing/src/tabs/connected-clients/samba-clients.ts
+++ b/file-sharing/src/tabs/connected-clients/samba-clients.ts
@@ -1,0 +1,157 @@
+import {
+  BashCommand,
+  ProcessError,
+  Server,
+} from "@45drives/houston-common-lib";
+import { ResultAsync, okAsync } from "neverthrow";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+
+const superuserOpts = { superuser: "try" as const };
+
+interface SmbStatusEncryption {
+  cipher?: string;
+  degree?: string;
+}
+
+interface SmbSession {
+  session_id?: string;
+  username?: string;
+  remote_machine?: string;
+  hostname?: string;
+  session_dialect?: string;
+  auth_time?: string;
+  encryption?: SmbStatusEncryption;
+}
+
+interface SmbTcon {
+  tcon_id?: string;
+  session_id?: string;
+  service?: string;
+  machine?: string;
+  connected_at?: string;
+  encryption?: SmbStatusEncryption;
+}
+
+interface SmbOpenFile {
+  opens?: Record<string, unknown>;
+}
+
+interface SmbStatusJson {
+  sessions?: Record<string, SmbSession>;
+  tcons?: Record<string, SmbTcon>;
+  open_files?: Record<string, SmbOpenFile>;
+}
+
+// `hostname` field looks like "ipv4:1.2.3.4:54321" or "ipv6:[::1]:1234"; pull
+// the printable address if we have it, else fall back to remote_machine.
+function parseHostname(session: SmbSession): string | null {
+  const h = session.hostname;
+  if (!h) return null;
+  const ipv4 = h.match(/^ipv4:([^:]+):\d+$/);
+  if (ipv4) return ipv4[1] ?? null;
+  const ipv6 = h.match(/^ipv6:\[([^\]]+)\]:\d+$/);
+  if (ipv6) return ipv6[1] ?? null;
+  return null;
+}
+
+function isEncrypted(enc: SmbStatusEncryption | undefined): boolean {
+  if (!enc) return false;
+  const cipher = (enc.cipher ?? "").trim();
+  const degree = (enc.degree ?? "").trim().toLowerCase();
+  return cipher !== "" && cipher !== "-" && degree !== "none" && degree !== "";
+}
+
+function parseDate(s: string | undefined): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function buildClients(status: SmbStatusJson): ConnectedClient[] {
+  const sessions = status.sessions ?? {};
+  const tcons = status.tcons ?? {};
+  const openFiles = status.open_files ?? {};
+
+  // Pre-compute per-(session,tcon) open-file counts.
+  const openCounts = new Map<string, number>();
+  for (const file of Object.values(openFiles)) {
+    for (const key of Object.keys(file.opens ?? {})) {
+      openCounts.set(key, (openCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const rows: ConnectedClient[] = [];
+  for (const tcon of Object.values(tcons)) {
+    const sessionId = tcon.session_id ?? "";
+    const session = sessions[sessionId] ?? {};
+    const tconId = tcon.tcon_id ?? "";
+    const key = `${sessionId}/${tconId}`;
+
+    rows.push({
+      id: `samba:${key}`,
+      protocol: "samba",
+      user: session.username ?? null,
+      ip: session.remote_machine ?? tcon.machine ?? "",
+      hostname: parseHostname(session),
+      protocolVersion: session.session_dialect ?? "SMB",
+      share: tcon.service ?? null,
+      connectedSince: parseDate(tcon.connected_at) ?? parseDate(session.auth_time),
+      openFiles: openCounts.get(key) ?? 0,
+      encrypted: isEncrypted(tcon.encryption) || isEncrypted(session.encryption),
+    });
+  }
+
+  // Sessions without a tcon (rare but possible during connect) — surface them too.
+  const tconnedSessions = new Set(
+    Object.values(tcons).map((t) => t.session_id ?? "")
+  );
+  for (const [sid, session] of Object.entries(sessions)) {
+    if (tconnedSessions.has(sid)) continue;
+    rows.push({
+      id: `samba:${sid}/-`,
+      protocol: "samba",
+      user: session.username ?? null,
+      ip: session.remote_machine ?? "",
+      hostname: parseHostname(session),
+      protocolVersion: session.session_dialect ?? "SMB",
+      share: null,
+      connectedSince: parseDate(session.auth_time),
+      openFiles: 0,
+      encrypted: isEncrypted(session.encryption),
+    });
+  }
+
+  return rows;
+}
+
+export function getSambaClients(server: Server): ResultAsync<ConnectedClient[], ProcessError> {
+  // Empty list if smbstatus is unavailable — keeps the tab functional on NFS-only boxes.
+  return server
+    .execute(new BashCommand("command -v smbstatus >/dev/null 2>&1"), false)
+    .andThen((proc) => {
+      if (!proc.succeeded()) return okAsync([] as ConnectedClient[]);
+      return server
+        .execute(new BashCommand("smbstatus -j 2>/dev/null", [], superuserOpts))
+        .map((p) => {
+          const out = p.getStdout().trim();
+          if (!out) return [] as ConnectedClient[];
+          try {
+            const parsed = JSON.parse(out) as SmbStatusJson;
+            return buildClients(parsed);
+          } catch {
+            return [] as ConnectedClient[];
+          }
+        });
+    });
+}
+
+export function kickSambaClient(server: Server, ip: string): ResultAsync<void, ProcessError> {
+  // smbcontrol takes an IP and disconnects every session from that client.
+  // Pass the IP via argv so shell metacharacters in user input can't be abused.
+  const safeIp = ip.replace(/[^0-9a-fA-F:.]/g, "");
+  return server
+    .execute(
+      new BashCommand(`smbcontrol smbd kill-client-ip "$1"`, [safeIp], superuserOpts)
+    )
+    .map(() => undefined);
+}

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -28,26 +28,70 @@ const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   []
 );
 
-// Diff successive polls to fire connect/disconnect toasts. Rows are
-// aggregated by logical client (protocol + user + IP) in the manager, so
-// client.id IS the logical-client key here — no further grouping needed.
-// `null` baseline = no diff yet (first load just records, never notifies);
-// baseline updates regardless of notifyOnChange so toggling that setting
-// on doesn't backfire stale events.
+// Diff successive polls to fire toasts covering five kinds of events:
+//  - Client connected: first time we see this logical client
+//  - Client disconnected: logical client gone
+//  - Client reconnected: same logical client, new session (different
+//    connectedSince) — typical kick → auto-reconnect case
+//  - Share connected: same logical client, same session, share appeared
+//  - Share disconnected: same logical client, same session, share dropped
+//
+// Rows are aggregated by logical client (protocol + user + IP) in the
+// manager, so client.id IS the logical-client key. `null` baseline = no
+// diff yet (first load just records, never notifies); baseline updates
+// regardless of notifyOnChange so toggling that setting on doesn't
+// backfire stale events.
 const previousByID = ref<Map<string, ConnectedClient> | null>(null);
-const clientLabel = (c: ConnectedClient): string => {
+const clientIdentity = (c: ConnectedClient): string => {
   const who = c.hostname ?? c.ip;
   return c.user ? `${c.user}@${who}` : who;
+};
+const clientLabel = (c: ConnectedClient): string => {
+  const id = clientIdentity(c);
+  return c.share ? `${id} · ${c.share}` : id;
+};
+const shareLabel = (c: ConnectedClient, share: string): string =>
+  `${share} · ${clientIdentity(c)}`;
+const shareSet = (s: string | null): Set<string> =>
+  new Set(s ? s.split(", ") : []);
+const sessionDiffers = (a: Date | null, b: Date | null): boolean => {
+  if (a === null && b === null) return false;
+  if (a === null || b === null) return true;
+  return a.getTime() !== b.getTime();
 };
 watch(clients, (newClients) => {
   const newMap = new Map(newClients.map((c) => [c.id, c]));
   const prev = previousByID.value;
   if (prev !== null && userSettings.value.connectedClients.notifyOnChange) {
     for (const c of newClients) {
-      if (!prev.has(c.id)) {
+      const old = prev.get(c.id);
+      if (!old) {
         pushNotification(
           new Notification(_("Client connected"), clientLabel(c), "info")
         );
+      } else if (sessionDiffers(c.connectedSince, old.connectedSince)) {
+        pushNotification(
+          new Notification(_("Client reconnected"), clientLabel(c), "info")
+        );
+      } else {
+        // Same id, same session — check for share-set delta. A user can
+        // mount additional shares or drop some while keeping their session.
+        const oldShares = shareSet(old.share);
+        const newShares = shareSet(c.share);
+        for (const s of newShares) {
+          if (!oldShares.has(s)) {
+            pushNotification(
+              new Notification(_("Share connected"), shareLabel(c, s), "info")
+            );
+          }
+        }
+        for (const s of oldShares) {
+          if (!newShares.has(s)) {
+            pushNotification(
+              new Notification(_("Share disconnected"), shareLabel(c, s), "info")
+            );
+          }
+        }
       }
     }
     for (const [id, c] of prev) {

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -122,7 +122,7 @@ const fallback = (v: string | null | undefined): string =>
         <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
           <Table
             noScroll
-            emptyText="No connected clients."
+            :emptyText='_("No connected clients.")'
             class="!border-none !shadow-none"
           >
             <template #thead>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -56,7 +56,9 @@ const startTimer = () => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
   const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
   refreshTimer = window.setInterval(() => {
-    actions.reloadClients();
+    // Background polling: silence errors so a chronic failure doesn't spam
+    // notifications every tick. Manual refresh (below) still surfaces them.
+    reloadClients().mapErr(() => undefined);
   }, ms);
 };
 
@@ -66,19 +68,21 @@ onUnmounted(() => {
 });
 watch(refreshIntervalSeconds, startTimer);
 
-const kickClient = (client: ConnectedClient) =>
-  assertConfirm({
+const kickClient = (client: ConnectedClient) => {
+  const label = client.hostname ? `${client.hostname} (${client.ip})` : client.ip;
+  return assertConfirm({
     header: _("Disconnect Samba client?"),
     body:
-      _("This drops all sessions from") +
-      ` ${client.ip}` +
-      ` (smbcontrol smbd kill-client-ip).`,
+      _("All open sessions and file handles from") +
+      ` ${label} ` +
+      _("will be closed. The client may reconnect automatically."),
     dangerous: true,
   })
     .andThen(() => manager)
     .andThen((m) => m.kickSamba(client.ip))
     .andThen(() => reloadClients())
-    .map(() => reportSuccess(_("Disconnected") + ` ${client.ip}`));
+    .map(() => reportSuccess(_("Disconnected") + ` ${label}`));
+};
 
 const actions = wrapActions({
   reloadClients,
@@ -97,11 +101,7 @@ const fallback = (v: string | null | undefined): string =>
         <div class="flex items-center justify-between gap-3 flex-wrap">
           <span>{{ _("Connected Clients") }}</span>
           <div class="flex items-center gap-2">
-            <SelectMenu
-              v-model="filter"
-              :options="filterOptions"
-              class="min-w-[8rem]"
-            />
+            <SelectMenu v-model="filter" :options="filterOptions" />
             <button
               class="btn btn-secondary inline-flex flex-row items-center gap-1"
               @click="actions.reloadClients()"
@@ -117,7 +117,6 @@ const fallback = (v: string | null | undefined): string =>
         <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
           <Table
             emptyText="No connected clients."
-            noScroll
             class="!border-none !shadow-none"
           >
             <template #thead>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -2,16 +2,19 @@
 import {
   CardContainer,
   CenteredCardColumn,
+  Notification,
   SelectMenu,
   Table,
   assertConfirm,
   computedResult,
+  pushNotification,
   reportSuccess,
   wrapActions,
   type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
 import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
@@ -30,16 +33,42 @@ const manager = server.map((s) => new ConnectedClientsManager(s));
 
 type Filter = "all" | ClientProtocol;
 const filter = ref<Filter>("all");
-const filterOptions: SelectMenuOption<Filter>[] = [
-  { label: _("All"), value: "all" },
-  { label: _("Samba"), value: "samba" },
-  { label: _("NFS"), value: "nfs" },
-];
 
 const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   () => manager.andThen((m) => m.getClients()),
   []
 );
+
+// Track previously-seen clients (full record, so we can label dropped rows
+// after they're gone). `null` baseline = no diff yet (first load just records,
+// never notifies). The baseline updates regardless of notifyOnChange so
+// toggling that setting on doesn't backfire stale events.
+const previousByID = ref<Map<string, ConnectedClient> | null>(null);
+const clientLabel = (c: ConnectedClient): string => {
+  const who = c.hostname ?? c.ip;
+  return c.user ? `${c.user}@${who}` : who;
+};
+watch(clients, (newClients) => {
+  const newMap = new Map(newClients.map((c) => [c.id, c]));
+  const prev = previousByID.value;
+  if (prev !== null && userSettings.value.connectedClients.notifyOnChange) {
+    for (const c of newClients) {
+      if (!prev.has(c.id)) {
+        pushNotification(
+          new Notification(_("Client connected"), clientLabel(c), "info")
+        );
+      }
+    }
+    for (const [id, c] of prev) {
+      if (!newMap.has(id)) {
+        pushNotification(
+          new Notification(_("Client disconnected"), clientLabel(c), "warning")
+        );
+      }
+    }
+  }
+  previousByID.value = newMap;
+});
 
 const filteredClients = computed(() =>
   filter.value === "all"
@@ -47,19 +76,75 @@ const filteredClients = computed(() =>
     : clients.value.filter((c) => c.protocol === filter.value)
 );
 
+const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
+  const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
+  const nfsCount = clients.value.filter((c) => c.protocol === "nfs").length;
+  const total = clients.value.length;
+  return [
+    { label: `${_("All")} (${total})`, value: "all" },
+    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
+    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
+  ];
+});
+
 const refreshIntervalSeconds = computed(
   () => userSettings.value.connectedClients.refreshIntervalSeconds
 );
+
+// `inFlight` gates concurrent fetches AND drives the spinner animation on
+// the refresh icon. Two reasons for the single source of truth:
+//  1) Skip-overlap: if a poll is still running when the next tick (or a
+//     manual click) fires, the new one no-ops. Cancelling + restarting
+//     hung calls (DNS timeout, slow nmblookup) just produces a fresh
+//     hang — and Cockpit lacks first-class cancellation primitives.
+//  2) Min-spin duration: local fetches usually finish in <100ms, so the
+//     animate-spin barely registers visually. Holding inFlight true for
+//     at least MIN_SPIN_MS lets the user perceive each refresh tick.
+const inFlight = ref(false);
+const MIN_SPIN_MS = 400;
+let spinStartedAt = 0;
+const beginInFlight = () => {
+  inFlight.value = true;
+  spinStartedAt = performance.now();
+};
+const releaseInFlight = () => {
+  const remaining = MIN_SPIN_MS - (performance.now() - spinStartedAt);
+  if (remaining <= 0) {
+    inFlight.value = false;
+  } else {
+    window.setTimeout(() => {
+      inFlight.value = false;
+    }, remaining);
+  }
+};
+
+// Background poll: silence errors so a chronic failure doesn't spam
+// notifications every tick. ResultAsync is PromiseLike, not Promise, so
+// we use .then(success, error) instead of .finally for cleanup.
+const pollTick = () => {
+  if (inFlight.value) return;
+  beginInFlight();
+  reloadClients()
+    .mapErr(() => undefined)
+    .then(releaseInFlight, releaseInFlight);
+};
+
+// Manual refresh: surfaces errors via wrapActions's notification handler.
+// If a poll is already in flight, return an immediately-resolved ok so
+// the click silently no-ops.
+const refreshNow = () => {
+  if (inFlight.value) return okAsync(undefined as void);
+  beginInFlight();
+  const r = reloadClients();
+  r.then(releaseInFlight, releaseInFlight);
+  return r;
+};
 
 let refreshTimer: number | undefined;
 const startTimer = () => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
   const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
-  refreshTimer = window.setInterval(() => {
-    // Background polling: silence errors so a chronic failure doesn't spam
-    // notifications every tick. Manual refresh (below) still surfaces them.
-    reloadClients().mapErr(() => undefined);
-  }, ms);
+  refreshTimer = window.setInterval(pollTick, ms);
 };
 
 onMounted(startTimer);
@@ -85,7 +170,7 @@ const kickClient = (client: ConnectedClient) => {
 };
 
 const actions = wrapActions({
-  reloadClients,
+  refreshNow,
   kickClient,
 });
 
@@ -104,10 +189,13 @@ const fallback = (v: string | null | undefined): string =>
             <SelectMenu v-model="filter" :options="filterOptions" />
             <button
               class="btn btn-secondary inline-flex flex-row items-center gap-1"
-              @click="actions.reloadClients()"
+              @click="actions.refreshNow()"
               :title="_('Refresh now')"
             >
-              <ArrowPathIcon class="size-icon icon-default" />
+              <ArrowPathIcon
+                class="size-icon icon-default"
+                :class="{ 'animate-spin': inFlight }"
+              />
               <span>{{ _("Refresh") }}</span>
             </button>
           </div>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -114,8 +114,14 @@ const fallback = (v: string | null | undefined): string =>
         </div>
       </template>
       <div class="card">
-        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
+        <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
+             Table's default scroll wrapper leaks the table's natural width up to
+             <html>, which combined with SelectMenu's scrollIntoView() causes the
+             page to scroll horizontally when the dropdown opens. Keeping the
+             scroll container at this level (and isolating layout) avoids it. -->
+        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
           <Table
+            noScroll
             emptyText="No connected clients."
             class="!border-none !shadow-none"
           >

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -13,7 +13,11 @@ import {
   type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/vue/20/solid";
 import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
@@ -39,10 +43,12 @@ const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   []
 );
 
-// Track previously-seen clients (full record, so we can label dropped rows
-// after they're gone). `null` baseline = no diff yet (first load just records,
-// never notifies). The baseline updates regardless of notifyOnChange so
-// toggling that setting on doesn't backfire stale events.
+// Diff successive polls to fire connect/disconnect toasts. Rows are
+// aggregated by logical client (protocol + user + IP) in the manager, so
+// client.id IS the logical-client key here — no further grouping needed.
+// `null` baseline = no diff yet (first load just records, never notifies);
+// baseline updates regardless of notifyOnChange so toggling that setting
+// on doesn't backfire stale events.
 const previousByID = ref<Map<string, ConnectedClient> | null>(null);
 const clientLabel = (c: ConnectedClient): string => {
   const who = c.hostname ?? c.ip;
@@ -75,6 +81,70 @@ const filteredClients = computed(() =>
     ? clients.value
     : clients.value.filter((c) => c.protocol === filter.value)
 );
+
+type SortField =
+  | "protocol"
+  | "user"
+  | "ip"
+  | "protocolVersion"
+  | "share"
+  | "connectedSince"
+  | "openFiles"
+  | "encrypted";
+type SortDir = "asc" | "desc";
+
+// `null` = unsorted (rows in arrival order from the manager). Clicking a
+// column cycles asc → desc → unsorted → asc, so users can clear a sort
+// without picking a different column.
+const sortBy = ref<SortField | null>("ip");
+const sortDir = ref<SortDir>("asc");
+
+const toggleSort = (field: SortField) => {
+  if (sortBy.value === field) {
+    if (sortDir.value === "asc") {
+      sortDir.value = "desc";
+    } else {
+      sortBy.value = null;
+    }
+  } else {
+    sortBy.value = field;
+    sortDir.value = "asc";
+  }
+};
+
+const sortValue = (c: ConnectedClient, f: SortField): string | number => {
+  switch (f) {
+    case "protocol":
+      return c.protocol;
+    case "user":
+      return c.user ?? "";
+    case "ip":
+      return c.ip;
+    case "protocolVersion":
+      return c.protocolVersion;
+    case "share":
+      return c.share ?? "";
+    case "connectedSince":
+      return c.connectedSince ? c.connectedSince.getTime() : 0;
+    case "openFiles":
+      return c.openFiles;
+    case "encrypted":
+      return c.encrypted ? 1 : 0;
+  }
+};
+
+const sortedClients = computed(() => {
+  const f = sortBy.value;
+  if (f === null) return filteredClients.value;
+  const arr = [...filteredClients.value];
+  const dir = sortDir.value === "asc" ? 1 : -1;
+  return arr.sort((a, b) => {
+    const av = sortValue(a, f);
+    const bv = sortValue(b, f);
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    return String(av).localeCompare(String(bv)) * dir;
+  });
+});
 
 const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
   const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
@@ -215,19 +285,67 @@ const fallback = (v: string | null | undefined): string =>
           >
             <template #thead>
               <tr>
-                <th scope="col">{{ _("Protocol") }}</th>
-                <th scope="col">{{ _("User") }}</th>
-                <th scope="col">{{ _("Client") }}</th>
-                <th scope="col">{{ _("Version") }}</th>
-                <th scope="col">{{ _("Share") }}</th>
-                <th scope="col">{{ _("Connected since") }}</th>
-                <th scope="col">{{ _("Open files") }}</th>
-                <th scope="col">{{ _("Encrypted") }}</th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
+                    {{ _("Protocol") }}
+                    <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
+                    {{ _("User") }}
+                    <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
+                    {{ _("Client") }}
+                    <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
+                    {{ _("Version") }}
+                    <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
+                    {{ _("Share") }}
+                    <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
+                    {{ _("Connected since") }}
+                    <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
+                    {{ _("Open files") }}
+                    <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
+                    {{ _("Encrypted") }}
+                    <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
+                    <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
+                  </button>
+                </th>
                 <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
               </tr>
             </template>
             <template #tbody>
-              <tr v-for="client in filteredClients" :key="client.id">
+              <tr v-for="client in sortedClients" :key="client.id">
                 <td>
                   <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
                 </td>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -112,6 +112,15 @@ const toggleSort = (field: SortField) => {
   }
 };
 
+// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
+// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
+// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
+const ipSortKey = (ip: string): string => {
+  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return ip;
+  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
+};
+
 const sortValue = (c: ConnectedClient, f: SortField): string | number => {
   switch (f) {
     case "protocol":
@@ -119,7 +128,7 @@ const sortValue = (c: ConnectedClient, f: SortField): string | number => {
     case "user":
       return c.user ?? "";
     case "ip":
-      return c.ip;
+      return ipSortKey(c.ip);
     case "protocolVersion":
       return c.protocolVersion;
     case "share":

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -1,42 +1,27 @@
 <script setup lang="ts">
 import {
-  CardContainer,
   CenteredCardColumn,
   Notification,
-  SelectMenu,
-  Table,
   assertConfirm,
   computedResult,
   pushNotification,
   reportSuccess,
   wrapActions,
-  type SelectMenuOption,
 } from "@45drives/houston-common-ui";
 import { getServer } from "@45drives/houston-common-lib";
-import {
-  ArrowPathIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from "@heroicons/vue/20/solid";
 import { okAsync } from "neverthrow";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
-import type {
-  ClientProtocol,
-  ConnectedClient,
-} from "@/tabs/connected-clients/data-types";
+import type { ConnectedClient } from "@/tabs/connected-clients/data-types";
+import ConnectedClientsTableView from "@/tabs/connected-clients/ui/ConnectedClientsTableView.vue";
 import { useUserSettings } from "@/common/user-settings";
 
 const _ = cockpit.gettext;
 
 const userSettings = useUserSettings();
-
 const server = getServer();
 const manager = server.map((s) => new ConnectedClientsManager(s));
-
-type Filter = "all" | ClientProtocol;
-const filter = ref<Filter>("all");
 
 const [clients, reloadClients] = computedResult<ConnectedClient[]>(
   () => manager.andThen((m) => m.getClients()),
@@ -74,96 +59,6 @@ watch(clients, (newClients) => {
     }
   }
   previousByID.value = newMap;
-});
-
-const filteredClients = computed(() =>
-  filter.value === "all"
-    ? clients.value
-    : clients.value.filter((c) => c.protocol === filter.value)
-);
-
-type SortField =
-  | "protocol"
-  | "user"
-  | "ip"
-  | "protocolVersion"
-  | "share"
-  | "connectedSince"
-  | "openFiles"
-  | "encrypted";
-type SortDir = "asc" | "desc";
-
-// `null` = unsorted (rows in arrival order from the manager). Clicking a
-// column cycles asc → desc → unsorted → asc, so users can clear a sort
-// without picking a different column.
-const sortBy = ref<SortField | null>("ip");
-const sortDir = ref<SortDir>("asc");
-
-const toggleSort = (field: SortField) => {
-  if (sortBy.value === field) {
-    if (sortDir.value === "asc") {
-      sortDir.value = "desc";
-    } else {
-      sortBy.value = null;
-    }
-  } else {
-    sortBy.value = field;
-    sortDir.value = "asc";
-  }
-};
-
-// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
-// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
-// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
-const ipSortKey = (ip: string): string => {
-  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-  if (!m) return ip;
-  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
-};
-
-const sortValue = (c: ConnectedClient, f: SortField): string | number => {
-  switch (f) {
-    case "protocol":
-      return c.protocol;
-    case "user":
-      return c.user ?? "";
-    case "ip":
-      return ipSortKey(c.ip);
-    case "protocolVersion":
-      return c.protocolVersion;
-    case "share":
-      return c.share ?? "";
-    case "connectedSince":
-      return c.connectedSince ? c.connectedSince.getTime() : 0;
-    case "openFiles":
-      return c.openFiles;
-    case "encrypted":
-      return c.encrypted ? 1 : 0;
-  }
-};
-
-const sortedClients = computed(() => {
-  const f = sortBy.value;
-  if (f === null) return filteredClients.value;
-  const arr = [...filteredClients.value];
-  const dir = sortDir.value === "asc" ? 1 : -1;
-  return arr.sort((a, b) => {
-    const av = sortValue(a, f);
-    const bv = sortValue(b, f);
-    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
-    return String(av).localeCompare(String(bv)) * dir;
-  });
-});
-
-const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
-  const sambaCount = clients.value.filter((c) => c.protocol === "samba").length;
-  const nfsCount = clients.value.filter((c) => c.protocol === "nfs").length;
-  const total = clients.value.length;
-  return [
-    { label: `${_("All")} (${total})`, value: "all" },
-    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
-    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
-  ];
 });
 
 const refreshIntervalSeconds = computed(
@@ -252,140 +147,15 @@ const actions = wrapActions({
   refreshNow,
   kickClient,
 });
-
-const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
-const fallback = (v: string | null | undefined): string =>
-  v && v.length > 0 ? v : "—";
 </script>
 
 <template>
   <CenteredCardColumn>
-    <CardContainer>
-      <template #header>
-        <div class="flex items-center justify-between gap-3 flex-wrap">
-          <span>{{ _("Connected Clients") }}</span>
-          <div class="flex items-center gap-2">
-            <SelectMenu v-model="filter" :options="filterOptions" />
-            <button
-              class="btn btn-secondary inline-flex flex-row items-center gap-1"
-              @click="actions.refreshNow()"
-              :title="_('Refresh now')"
-            >
-              <ArrowPathIcon
-                class="size-icon icon-default"
-                :class="{ 'animate-spin': inFlight }"
-              />
-              <span>{{ _("Refresh") }}</span>
-            </button>
-          </div>
-        </div>
-      </template>
-      <div class="card">
-        <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
-             Table's default scroll wrapper leaks the table's natural width up to
-             <html>, which combined with SelectMenu's scrollIntoView() causes the
-             page to scroll horizontally when the dropdown opens. Keeping the
-             scroll container at this level (and isolating layout) avoids it. -->
-        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
-          <Table
-            noScroll
-            :emptyText='_("No connected clients.")'
-            class="!border-none !shadow-none"
-          >
-            <template #thead>
-              <tr>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
-                    {{ _("Protocol") }}
-                    <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
-                    {{ _("User") }}
-                    <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
-                    {{ _("Client") }}
-                    <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
-                    {{ _("Version") }}
-                    <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
-                    {{ _("Share") }}
-                    <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
-                    {{ _("Connected since") }}
-                    <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
-                    {{ _("Open files") }}
-                    <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col">
-                  <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
-                    {{ _("Encrypted") }}
-                    <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
-                    <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
-                  </button>
-                </th>
-                <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
-              </tr>
-            </template>
-            <template #tbody>
-              <tr v-for="client in sortedClients" :key="client.id">
-                <td>
-                  <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
-                </td>
-                <td>{{ fallback(client.user) }}</td>
-                <td>
-                  <div class="flex flex-col">
-                    <span class="font-mono">{{ client.ip }}</span>
-                    <span v-if="client.hostname" class="muted-text text-sm">
-                      {{ client.hostname }}
-                    </span>
-                  </div>
-                </td>
-                <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
-                <td>{{ fallback(client.share) }}</td>
-                <td>{{ formatDate(client.connectedSince) }}</td>
-                <td>{{ client.openFiles }}</td>
-                <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
-                <td class="button-group-row justify-end">
-                  <button
-                    v-if="client.protocol === 'samba'"
-                    class="btn btn-secondary btn-sm"
-                    @click="actions.kickClient(client)"
-                  >
-                    {{ _("Disconnect") }}
-                  </button>
-                </td>
-              </tr>
-            </template>
-          </Table>
-        </div>
-      </div>
-    </CardContainer>
+    <ConnectedClientsTableView
+      :clients="clients"
+      :inFlight="inFlight"
+      @refresh="actions.refreshNow()"
+      @kick="(c) => actions.kickClient(c)"
+    />
   </CenteredCardColumn>
 </template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import {
+  CardContainer,
+  CenteredCardColumn,
+  SelectMenu,
+  Table,
+  assertConfirm,
+  computedResult,
+  reportSuccess,
+  wrapActions,
+  type SelectMenuOption,
+} from "@45drives/houston-common-ui";
+import { getServer } from "@45drives/houston-common-lib";
+import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+
+import { ConnectedClientsManager } from "@/tabs/connected-clients/connected-clients-manager";
+import type {
+  ClientProtocol,
+  ConnectedClient,
+} from "@/tabs/connected-clients/data-types";
+import { useUserSettings } from "@/common/user-settings";
+
+const _ = cockpit.gettext;
+
+const userSettings = useUserSettings();
+
+const server = getServer();
+const manager = server.map((s) => new ConnectedClientsManager(s));
+
+type Filter = "all" | ClientProtocol;
+const filter = ref<Filter>("all");
+const filterOptions: SelectMenuOption<Filter>[] = [
+  { label: _("All"), value: "all" },
+  { label: _("Samba"), value: "samba" },
+  { label: _("NFS"), value: "nfs" },
+];
+
+const [clients, reloadClients] = computedResult<ConnectedClient[]>(
+  () => manager.andThen((m) => m.getClients()),
+  []
+);
+
+const filteredClients = computed(() =>
+  filter.value === "all"
+    ? clients.value
+    : clients.value.filter((c) => c.protocol === filter.value)
+);
+
+const refreshIntervalSeconds = computed(
+  () => userSettings.value.connectedClients.refreshIntervalSeconds
+);
+
+let refreshTimer: number | undefined;
+const startTimer = () => {
+  if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+  const ms = Math.max(1, refreshIntervalSeconds.value) * 1000;
+  refreshTimer = window.setInterval(() => {
+    actions.reloadClients();
+  }, ms);
+};
+
+onMounted(startTimer);
+onUnmounted(() => {
+  if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+});
+watch(refreshIntervalSeconds, startTimer);
+
+const kickClient = (client: ConnectedClient) =>
+  assertConfirm({
+    header: _("Disconnect Samba client?"),
+    body:
+      _("This drops all sessions from") +
+      ` ${client.ip}` +
+      ` (smbcontrol smbd kill-client-ip).`,
+    dangerous: true,
+  })
+    .andThen(() => manager)
+    .andThen((m) => m.kickSamba(client.ip))
+    .andThen(() => reloadClients())
+    .map(() => reportSuccess(_("Disconnected") + ` ${client.ip}`));
+
+const actions = wrapActions({
+  reloadClients,
+  kickClient,
+});
+
+const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
+const fallback = (v: string | null | undefined): string =>
+  v && v.length > 0 ? v : "—";
+</script>
+
+<template>
+  <CenteredCardColumn>
+    <CardContainer>
+      <template #header>
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <span>{{ _("Connected Clients") }}</span>
+          <div class="flex items-center gap-2">
+            <SelectMenu
+              v-model="filter"
+              :options="filterOptions"
+              class="min-w-[8rem]"
+            />
+            <button
+              class="btn btn-secondary inline-flex flex-row items-center gap-1"
+              @click="actions.reloadClients()"
+              :title="_('Refresh now')"
+            >
+              <ArrowPathIcon class="size-icon icon-default" />
+              <span>{{ _("Refresh") }}</span>
+            </button>
+          </div>
+        </div>
+      </template>
+      <div class="card">
+        <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-hidden">
+          <Table
+            emptyText="No connected clients."
+            noScroll
+            class="!border-none !shadow-none"
+          >
+            <template #thead>
+              <tr>
+                <th scope="col">{{ _("Protocol") }}</th>
+                <th scope="col">{{ _("User") }}</th>
+                <th scope="col">{{ _("Client") }}</th>
+                <th scope="col">{{ _("Version") }}</th>
+                <th scope="col">{{ _("Share") }}</th>
+                <th scope="col">{{ _("Connected since") }}</th>
+                <th scope="col">{{ _("Open files") }}</th>
+                <th scope="col">{{ _("Encrypted") }}</th>
+                <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+              </tr>
+            </template>
+            <template #tbody>
+              <tr v-for="client in filteredClients" :key="client.id">
+                <td>
+                  <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
+                </td>
+                <td>{{ fallback(client.user) }}</td>
+                <td>
+                  <div class="flex flex-col">
+                    <span class="font-mono">{{ client.ip }}</span>
+                    <span v-if="client.hostname" class="muted-text text-sm">
+                      {{ client.hostname }}
+                    </span>
+                  </div>
+                </td>
+                <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
+                <td>{{ fallback(client.share) }}</td>
+                <td>{{ formatDate(client.connectedSince) }}</td>
+                <td>{{ client.openFiles }}</td>
+                <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
+                <td class="button-group-row justify-end">
+                  <button
+                    v-if="client.protocol === 'samba'"
+                    class="btn btn-secondary btn-sm"
+                    @click="actions.kickClient(client)"
+                  >
+                    {{ _("Disconnect") }}
+                  </button>
+                </td>
+              </tr>
+            </template>
+          </Table>
+        </div>
+      </div>
+    </CardContainer>
+  </CenteredCardColumn>
+</template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTabMain.vue
@@ -52,6 +52,16 @@ const clientLabel = (c: ConnectedClient): string => {
 };
 const shareLabel = (c: ConnectedClient, share: string): string =>
   `${share} · ${clientIdentity(c)}`;
+
+// Per-protocol toast titles. Strings stay as literal _() calls at each branch
+// so the gettext extractor catches them; using a key-driven helper would hide
+// them from the extraction tooling.
+const connectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client connected") : _("NFS client connected");
+const reconnectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client reconnected") : _("NFS client reconnected");
+const disconnectedTitle = (c: ConnectedClient): string =>
+  c.protocol === "samba" ? _("Samba client disconnected") : _("NFS client disconnected");
 const shareSet = (s: string | null): Set<string> =>
   new Set(s ? s.split(", ") : []);
 const sessionDiffers = (a: Date | null, b: Date | null): boolean => {
@@ -67,11 +77,11 @@ watch(clients, (newClients) => {
       const old = prev.get(c.id);
       if (!old) {
         pushNotification(
-          new Notification(_("Client connected"), clientLabel(c), "info")
+          new Notification(connectedTitle(c), clientLabel(c), "info")
         );
       } else if (sessionDiffers(c.connectedSince, old.connectedSince)) {
         pushNotification(
-          new Notification(_("Client reconnected"), clientLabel(c), "info")
+          new Notification(reconnectedTitle(c), clientLabel(c), "info")
         );
       } else {
         // Same id, same session — check for share-set delta. A user can
@@ -97,7 +107,7 @@ watch(clients, (newClients) => {
     for (const [id, c] of prev) {
       if (!newMap.has(id)) {
         pushNotification(
-          new Notification(_("Client disconnected"), clientLabel(c), "warning")
+          new Notification(disconnectedTitle(c), clientLabel(c), "warning")
         );
       }
     }
@@ -121,6 +131,7 @@ const refreshIntervalSeconds = computed(
 const inFlight = ref(false);
 const MIN_SPIN_MS = 400;
 let spinStartedAt = 0;
+let spinReleaseTimer: number | undefined;
 const beginInFlight = () => {
   inFlight.value = true;
   spinStartedAt = performance.now();
@@ -130,7 +141,10 @@ const releaseInFlight = () => {
   if (remaining <= 0) {
     inFlight.value = false;
   } else {
-    window.setTimeout(() => {
+    // Tracked so onUnmounted can clear it — otherwise a pending tick fires
+    // after teardown and Vue warns about mutating a destroyed component.
+    spinReleaseTimer = window.setTimeout(() => {
+      spinReleaseTimer = undefined;
       inFlight.value = false;
     }, remaining);
   }
@@ -168,6 +182,7 @@ const startTimer = () => {
 onMounted(startTimer);
 onUnmounted(() => {
   if (refreshTimer !== undefined) window.clearInterval(refreshTimer);
+  if (spinReleaseTimer !== undefined) window.clearTimeout(spinReleaseTimer);
 });
 watch(refreshIntervalSeconds, startTimer);
 

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -126,6 +126,16 @@ const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
 const fallback = (v: string | null | undefined): string =>
   v && v.length > 0 ? v : "—";
 
+// NFS Share is derived from active opens because the kernel doesn't expose a
+// per-client mount list for NFSv4 (no tcon concept). Surface that caveat as
+// a hover tooltip so operators don't read a blank cell as "not mounted".
+const shareTooltip = (c: ConnectedClient): string | undefined => {
+  if (c.protocol !== "nfs") return undefined;
+  return _(
+    'NFS: derived from active opens (the kernel doesn\'t expose a per-client mount list for NFSv4). An idle-but-mounted client will show "—" here even when connected; the column reflects what is currently being read/written, not what is mounted.'
+  );
+};
+
 // Column definitions for the sortable header row. Labels are wrapped in _()
 // at module init time, matching the convention used elsewhere in this project
 // (e.g. tabVisibilityOptions in UserSettingsView.vue).
@@ -211,7 +221,9 @@ const sortableColumns: { field: SortField; label: string }[] = [
                 </div>
               </td>
               <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
-              <td>{{ fallback(client.share) }}</td>
+              <td :title="shareTooltip(client)">
+                {{ fallback(client.share) }}
+              </td>
               <td>{{ formatDate(client.connectedSince) }}</td>
               <td>{{ client.openFiles }}</td>
               <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -240,6 +240,9 @@ const sortableColumns: { field: SortField; label: string }[] = [
           </template>
         </Table>
       </div>
+      <p class="text-muted text-sm mt-3">
+        {{ _("Note: NFS clients only appear while their NFSv4 lease is active (~90 s of recent I/O). An idle-but-mounted client may briefly disappear from this list until its next operation re-confirms the lease.") }}
+      </p>
     </div>
   </CardContainer>
 </template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -149,7 +149,7 @@ const sortableColumns: { field: SortField; label: string }[] = [
         <div class="flex items-center gap-2">
           <SelectMenu v-model="filter" :options="filterOptions" />
           <button
-            class="btn btn-secondary inline-flex flex-row items-center gap-1"
+            class="btn btn-secondary inline-flex flex-row items-center gap-1 text-base font-normal"
             @click="emit('refresh')"
             :title="_('Refresh now')"
           >

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -1,0 +1,258 @@
+<script setup lang="ts">
+import {
+  CardContainer,
+  SelectMenu,
+  Table,
+  type SelectMenuOption,
+} from "@45drives/houston-common-ui";
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/vue/20/solid";
+import { computed, ref } from "vue";
+
+import type {
+  ClientProtocol,
+  ConnectedClient,
+} from "@/tabs/connected-clients/data-types";
+
+const _ = cockpit.gettext;
+
+const props = defineProps<{
+  clients: ConnectedClient[];
+  inFlight: boolean;
+}>();
+
+const emit = defineEmits<{
+  refresh: [];
+  kick: [client: ConnectedClient];
+}>();
+
+type Filter = "all" | ClientProtocol;
+const filter = ref<Filter>("all");
+
+const filteredClients = computed(() =>
+  filter.value === "all"
+    ? props.clients
+    : props.clients.filter((c) => c.protocol === filter.value)
+);
+
+const filterOptions = computed<SelectMenuOption<Filter>[]>(() => {
+  const sambaCount = props.clients.filter((c) => c.protocol === "samba").length;
+  const nfsCount = props.clients.filter((c) => c.protocol === "nfs").length;
+  const total = props.clients.length;
+  return [
+    { label: `${_("All")} (${total})`, value: "all" },
+    { label: `${_("Samba")} (${sambaCount})`, value: "samba" },
+    { label: `${_("NFS")} (${nfsCount})`, value: "nfs" },
+  ];
+});
+
+type SortField =
+  | "protocol"
+  | "user"
+  | "ip"
+  | "protocolVersion"
+  | "share"
+  | "connectedSince"
+  | "openFiles"
+  | "encrypted";
+type SortDir = "asc" | "desc";
+
+// `null` = unsorted (rows in arrival order from the manager). Clicking a
+// column cycles asc → desc → unsorted → asc, so users can clear a sort
+// without picking a different column.
+const sortBy = ref<SortField | null>("ip");
+const sortDir = ref<SortDir>("asc");
+
+const toggleSort = (field: SortField) => {
+  if (sortBy.value === field) {
+    if (sortDir.value === "asc") {
+      sortDir.value = "desc";
+    } else {
+      sortBy.value = null;
+    }
+  } else {
+    sortBy.value = field;
+    sortDir.value = "asc";
+  }
+};
+
+// Zero-pad each IPv4 octet so a lexicographic compare sorts numerically.
+// IPv6 falls through as-is (expanding `::` for proper ordering is a v2
+// concern; in practice CIFS/NFS clients on a LAN are overwhelmingly v4).
+const ipSortKey = (ip: string): string => {
+  const m = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return ip;
+  return m.slice(1).map((s) => s.padStart(3, "0")).join(".");
+};
+
+const sortValue = (c: ConnectedClient, f: SortField): string | number => {
+  switch (f) {
+    case "protocol":
+      return c.protocol;
+    case "user":
+      return c.user ?? "";
+    case "ip":
+      return ipSortKey(c.ip);
+    case "protocolVersion":
+      return c.protocolVersion;
+    case "share":
+      return c.share ?? "";
+    case "connectedSince":
+      return c.connectedSince ? c.connectedSince.getTime() : 0;
+    case "openFiles":
+      return c.openFiles;
+    case "encrypted":
+      return c.encrypted ? 1 : 0;
+  }
+};
+
+const sortedClients = computed(() => {
+  const f = sortBy.value;
+  if (f === null) return filteredClients.value;
+  const arr = [...filteredClients.value];
+  const dir = sortDir.value === "asc" ? 1 : -1;
+  return arr.sort((a, b) => {
+    const av = sortValue(a, f);
+    const bv = sortValue(b, f);
+    if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+    return String(av).localeCompare(String(bv)) * dir;
+  });
+});
+
+const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
+const fallback = (v: string | null | undefined): string =>
+  v && v.length > 0 ? v : "—";
+</script>
+
+<template>
+  <CardContainer>
+    <template #header>
+      <div class="flex items-center justify-between gap-3 flex-wrap">
+        <span>{{ _("Connected Clients") }}</span>
+        <div class="flex items-center gap-2">
+          <SelectMenu v-model="filter" :options="filterOptions" />
+          <button
+            class="btn btn-secondary inline-flex flex-row items-center gap-1"
+            @click="emit('refresh')"
+            :title="_('Refresh now')"
+          >
+            <ArrowPathIcon
+              class="size-icon icon-default"
+              :class="{ 'animate-spin': inFlight }"
+            />
+            <span>{{ _("Refresh") }}</span>
+          </button>
+        </div>
+      </div>
+    </template>
+    <div class="card">
+      <!-- noScroll + outer overflow-x-auto + contain:layout: the houston-common-ui
+           Table's default scroll wrapper leaks the table's natural width up to
+           <html>, which combined with SelectMenu's scrollIntoView() causes the
+           page to scroll horizontally when the dropdown opens. Keeping the
+           scroll container at this level (and isolating layout) avoids it. -->
+      <div class="sm:shadow sm:rounded-lg sm:border sm:border-default overflow-x-auto [contain:layout]">
+        <Table
+          noScroll
+          :emptyText='_("No connected clients.")'
+          class="!border-none !shadow-none"
+        >
+          <template #thead>
+            <tr>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
+                  {{ _("Protocol") }}
+                  <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
+                  {{ _("User") }}
+                  <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
+                  {{ _("Client") }}
+                  <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
+                  {{ _("Version") }}
+                  <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
+                  {{ _("Share") }}
+                  <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
+                  {{ _("Connected since") }}
+                  <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
+                  {{ _("Open files") }}
+                  <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
+                  {{ _("Encrypted") }}
+                  <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
+                  <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
+                </button>
+              </th>
+              <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+            </tr>
+          </template>
+          <template #tbody>
+            <tr v-for="client in sortedClients" :key="client.id">
+              <td>
+                <span class="uppercase font-mono text-sm">{{ client.protocol }}</span>
+              </td>
+              <td>{{ fallback(client.user) }}</td>
+              <td>
+                <div class="flex flex-col">
+                  <span class="font-mono">{{ client.ip }}</span>
+                  <span v-if="client.hostname" class="muted-text text-sm">
+                    {{ client.hostname }}
+                  </span>
+                </div>
+              </td>
+              <td class="font-mono text-sm">{{ client.protocolVersion }}</td>
+              <td>{{ fallback(client.share) }}</td>
+              <td>{{ formatDate(client.connectedSince) }}</td>
+              <td>{{ client.openFiles }}</td>
+              <td>{{ client.encrypted ? _("Yes") : _("No") }}</td>
+              <td class="button-group-row justify-end">
+                <button
+                  v-if="client.protocol === 'samba'"
+                  class="btn btn-secondary btn-sm"
+                  @click="emit('kick', client)"
+                >
+                  {{ _("Disconnect") }}
+                </button>
+              </td>
+            </tr>
+          </template>
+        </Table>
+      </div>
+    </div>
+  </CardContainer>
+</template>

--- a/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
+++ b/file-sharing/src/tabs/connected-clients/ui/ConnectedClientsTableView.vue
@@ -125,6 +125,20 @@ const sortedClients = computed(() => {
 const formatDate = (d: Date | null): string => (d ? d.toLocaleString() : "—");
 const fallback = (v: string | null | undefined): string =>
   v && v.length > 0 ? v : "—";
+
+// Column definitions for the sortable header row. Labels are wrapped in _()
+// at module init time, matching the convention used elsewhere in this project
+// (e.g. tabVisibilityOptions in UserSettingsView.vue).
+const sortableColumns: { field: SortField; label: string }[] = [
+  { field: "protocol", label: _("Protocol") },
+  { field: "user", label: _("User") },
+  { field: "ip", label: _("Client") },
+  { field: "protocolVersion", label: _("Version") },
+  { field: "share", label: _("Share") },
+  { field: "connectedSince", label: _("Connected since") },
+  { field: "openFiles", label: _("Open files") },
+  { field: "encrypted", label: _("Encrypted") },
+];
 </script>
 
 <template>
@@ -162,63 +176,24 @@ const fallback = (v: string | null | undefined): string =>
         >
           <template #thead>
             <tr>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocol')">
-                  {{ _("Protocol") }}
-                  <ChevronUpIcon v-if="sortBy === 'protocol' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'protocol' && sortDir === 'desc'" class="size-4" />
+              <th v-for="col in sortableColumns" :key="col.field" scope="col">
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1"
+                  @click="toggleSort(col.field)"
+                >
+                  {{ col.label }}
+                  <ChevronUpIcon
+                    v-if="sortBy === col.field && sortDir === 'asc'"
+                    class="size-4"
+                  />
+                  <ChevronDownIcon
+                    v-else-if="sortBy === col.field && sortDir === 'desc'"
+                    class="size-4"
+                  />
                 </button>
               </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('user')">
-                  {{ _("User") }}
-                  <ChevronUpIcon v-if="sortBy === 'user' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'user' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('ip')">
-                  {{ _("Client") }}
-                  <ChevronUpIcon v-if="sortBy === 'ip' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'ip' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('protocolVersion')">
-                  {{ _("Version") }}
-                  <ChevronUpIcon v-if="sortBy === 'protocolVersion' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'protocolVersion' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('share')">
-                  {{ _("Share") }}
-                  <ChevronUpIcon v-if="sortBy === 'share' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'share' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('connectedSince')">
-                  {{ _("Connected since") }}
-                  <ChevronUpIcon v-if="sortBy === 'connectedSince' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'connectedSince' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('openFiles')">
-                  {{ _("Open files") }}
-                  <ChevronUpIcon v-if="sortBy === 'openFiles' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'openFiles' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col">
-                <button type="button" class="inline-flex items-center gap-1" @click="toggleSort('encrypted')">
-                  {{ _("Encrypted") }}
-                  <ChevronUpIcon v-if="sortBy === 'encrypted' && sortDir === 'asc'" class="size-4" />
-                  <ChevronDownIcon v-else-if="sortBy === 'encrypted' && sortDir === 'desc'" class="size-4" />
-                </button>
-              </th>
-              <th scope="col" class="justify-end"><span class="sr-only">Actions</span></th>
+              <th scope="col" class="justify-end"><span class="sr-only">{{ _("Actions") }}</span></th>
             </tr>
           </template>
           <template #tbody>

--- a/file-sharing/src/tabs/connected-clients/ui/index.ts
+++ b/file-sharing/src/tabs/connected-clients/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as ConnectedClientsTabMain } from "./ConnectedClientsTabMain.vue";


### PR DESCRIPTION
## Depends on #185 — must merge after that PR

This PR adds unit tests for the Connected Clients feature introduced in [#185](https://github.com/45Drives/cockpit-file-sharing/pull/185). Its commits sit on top of `feat/connected-clients`, so attempting to merge this one first will produce conflicts — please merge #185 first, then rebase/merge this against the new `main`.

The feature PR was kept deliberately lean to maximize reviewability; tests landed here so the diff stays separable.

---

## What's tested

Four pure-function helpers backing the feature. None of these touch subprocesses or the DOM, so no mocking is required — the tests feed in canned strings/objects and assert on the returned data structures.

| File | Helper | Cases |
|---|---|---|
| `samba-clients.test.ts` | `buildClients(SmbStatusJson)` | 8 |
| `nfs-clients.test.ts` | `parseDump`, `parseMountInfo`, `parseExports`, `parseStates`, `deriveShares` | 37 |
| `hostname-resolver.test.ts` | `parseNmblookup(stdout, ips)` | 6 |
| `connected-clients-manager.test.ts` | `aggregateByLogicalClient(rows)` | 11 |

**Total: 67 tests.** All passing under `vitest run`, verified flake-free across 3 sequential runs.

To keep the test surface honest, the previously module-private helpers that the tests reach into are now `export`ed:

- `samba-clients.ts::buildClients`
- `nfs-clients.ts::parseDump` + `parseMountInfo` + `parseExports` + `parseStates` + `deriveShares`
- `hostname-resolver.ts::parseNmblookup`
- `connected-clients-manager.ts::aggregateByLogicalClient`

This expands the module API but only by the exact surface area covered by tests; the existing public entry points (`getSambaClients`, `getNfsClients`, `resolveHostnames`, `ConnectedClientsManager`, `kickSambaClient`) are unchanged.

---

## Coverage highlights

- **buildClients**: handles empty input, single-tcon sessions, multi-tcon sessions, sessions without tcons (rare during connect), open-files counting by `(session_id, tcon_id)` key, mixed encryption states, `tcon.connected_at` preference over `session.auth_time`, deterministic `id` format.
- **parseDump**: empty dump, single client info+states, multi-client framing, IPv6 address extraction from bracketed forms, name parsing falling through cleanly when no hostname follows, missing `minor version` falls back to `NFSv4`, states-line counting. Also covers the recent-kernel format quirks: quote-wrapped `address` / `name` values strip cleanly (the parser must not leak literal quotes into the UI), the `---MTIME---` marker parses into a `connectedSince` Date matching the source epoch, and missing / non-numeric / zero MTIME values yield null (graceful degradation on older kernels or when `stat` produces no output). Regression coverage for the empty-`clients/`-directory case: a stray `---CLIENT:*---` block (from bash's literal-glob behavior when the dir exists but has no children) drops cleanly instead of rendering a phantom row, and any CLIENT block without an `address:` line is similarly skipped. Integration coverage for the new NFS Share derivation: an idle client (no `states`) keeps `share=null`; an active client (open files on an exported mount) gets `share` populated; global `MOUNTINFO` / `EXPORTS` context applies across every CLIENT in the dump; and a missing global context degrades gracefully (share=null) rather than crashing.
- **parseMountInfo**: extracts `major:minor` → list-of-mount-paths from `/proc/self/mountinfo`; collects *all* paths for the same superblock (so multi-mount filesystems — bind mounts, ZFS secondary mountpoints, LVM-bind — don't lose candidates to last-write-wins); ignores junk / truncated lines; empty input yields an empty map.
- **parseExports**: first whitespace-delimited path token per non-comment line; comment / blank lines skipped; requires path to start with `/` so wildcards / netgroups (not valid for NFSv4) don't pollute the matchable set.
- **parseStates**: extracts `(filename, superblock)` tuples from each line; converts the kernel's hex `major:minor:inode` to decimal `major:minor` so it joins against `mountinfo`'s format; lines missing either field are skipped.
- **deriveShares**: returns the matching export for a single open; comma-joins (sorted) when files span multiple exports; dedupes when multiple files map to the same export; returns null on no opens / no mount-info match / no export match / empty exports set; on multi-mount filesystems, picks the export-matching mount path regardless of mountinfo line order (regression coverage for an earlier last-write-wins bug).
- **parseNmblookup**: empty input → all IPs null, `<00>` record extraction, `<GROUP>` (workgroup) records skipped so a workgroup name never becomes a hostname, "No reply" hosts stay null, mixed-batch attribution, first non-group `<00>` wins.
- **aggregateByLogicalClient**: id rewrites to logical-client key, multi-tcon merge with share comma-join + openFiles sum + encryption AND, conservative encryption (any unencrypted tcon → row false), earliest connectedSince across tcons (ignoring nulls), no cross-protocol or cross-user merging, duplicate-share dedup, null-share fallthrough.

---

## How to run

```bash
yarn --cwd file-sharing test
```

No new test framework, no new config file, no CI changes. The repo already has `vitest` configured (`test` and `test:app` scripts in `file-sharing/package.json`); we follow exactly the convention of the existing `file-sharing/src/tabs/nfs/exports-parser.test.ts`.

---

## Known pre-existing test noise (not from this PR)

When running `yarn test`, two pre-existing items in `@45drives/houston-common-lib`'s `nodeDriver.ts` may surface:

1. **Intermittent `EEXIST: mkdir '/home/.houston'`** when multiple test files load `houston-common-lib` in parallel — the driver's `existsSync` + `mkdirSync` is a TOCTOU race. Workaround: `rm -rf ~/.houston && yarn test`. Proper upstream fix: pass `{ recursive: true }` to `mkdirSync` on line 30 of `lib/driver/nodeDriver.ts`.
2. **`Unhandled Rejection: Cannot read properties of undefined (reading 'on')`** at `nodeDriver.ts:41` — calling `vitest.afterAll(...)` from module-load context (outside a test suite). Tests still pass; the rejection is noise. Also pre-existing — fires for `exports-parser.test.ts` too.

Neither is introduced by this PR. Happy to file a separate upstream issue against `houston-common` if useful.

---

## Files changed

```
file-sharing/src/tabs/connected-clients/samba-clients.ts          (+1 line: export)
file-sharing/src/tabs/connected-clients/nfs-clients.ts            (+1 line: export)
file-sharing/src/tabs/connected-clients/hostname-resolver.ts      (+1 line: export)
file-sharing/src/tabs/connected-clients/connected-clients-manager.ts (+1 line: export)
file-sharing/src/tabs/connected-clients/samba-clients.test.ts     (new)
file-sharing/src/tabs/connected-clients/nfs-clients.test.ts       (new — extended with 7 cases: quote-strip, dentry mtime, empty-glob regression)
file-sharing/src/tabs/connected-clients/hostname-resolver.test.ts (new)
file-sharing/src/tabs/connected-clients/connected-clients-manager.test.ts (new)
```


