### PR TITLE
Read-only mode for Samba, NFS, and iSCSI tabs

### DIFF
--- a/file-sharing/src/common/injectionKeys.ts
+++ b/file-sharing/src/common/injectionKeys.ts
@@ -1,7 +1,17 @@
-import { type InjectionKey, type Ref } from "vue";
+import { type ComputedRef, type InjectionKey, type Ref } from "vue";
 import { getServerCluster } from "@45drives/houston-common-lib";
 
 export const serverClusterInjectionKey = Symbol() as InjectionKey<
   ReturnType<typeof getServerCluster>
 >;
 export const cephClientNameInjectionKey = Symbol() as InjectionKey<Ref<`client.${string}`>>;
+
+/**
+ * Per-tab read-only flag. Each tab's TabMain provides this from its
+ * corresponding user-setting (samba.readOnly / nfs.readOnly / iscsi.readOnly);
+ * editor components inject it and gate write affordances. Provided as a
+ * ComputedRef so toggling the setting in the modal propagates without a
+ * remount. The default (false) lets components that aren't under a provider
+ * — or that are independently mounted in tests — render in editable mode.
+ */
+export const readOnlyInjectionKey = Symbol() as InjectionKey<ComputedRef<boolean>>;

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -90,10 +90,18 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
           :options="tabVisibilityOptions"
         />
       </InputLabelWrapper>
-      <ToggleSwitch v-model="tempUserSettings.samba.readOnly">
+      <ToggleSwitch
+        v-model="tempUserSettings.samba.readOnly"
+        :disabled="tempUserSettings.samba.readOnlyLocked"
+      >
         {{ _("Read-only mode") }}
         <template #description>
-          {{ _("Hide every edit affordance in the Samba tab (add/edit/delete/import). Useful when the Samba config is owned externally (config-as-code, Ansible, manual edits) and Cockpit is only meant to visualize.") }}
+          <span v-if="tempUserSettings.samba.readOnlyLocked">
+            {{ _("Locked: this value is pinned via /etc/cockpit-file-sharing.conf.json (samba.readOnlyLocked = true). Edit the file to change it.") }}
+          </span>
+          <span v-else>
+            {{ _("Hide every edit affordance in the Samba tab (add/edit/delete/import). Useful when the Samba config is owned externally (config-as-code, Ansible, manual edits) and Cockpit is only meant to visualize.") }}
+          </span>
         </template>
       </ToggleSwitch>
       <div class="text-header">NFS</div>
@@ -113,10 +121,18 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
         </template>
         <SelectMenu v-model="tempUserSettings.nfs.tabVisibility" :options="tabVisibilityOptions" />
       </InputLabelWrapper>
-      <ToggleSwitch v-model="tempUserSettings.nfs.readOnly">
+      <ToggleSwitch
+        v-model="tempUserSettings.nfs.readOnly"
+        :disabled="tempUserSettings.nfs.readOnlyLocked"
+      >
         {{ _("Read-only mode") }}
         <template #description>
-          {{ _("Hide every edit affordance in the NFS tab (add/edit/delete/import). Useful when /etc/exports (or the configured file) is owned externally and Cockpit is only meant to visualize.") }}
+          <span v-if="tempUserSettings.nfs.readOnlyLocked">
+            {{ _("Locked: this value is pinned via /etc/cockpit-file-sharing.conf.json (nfs.readOnlyLocked = true). Edit the file to change it.") }}
+          </span>
+          <span v-else>
+            {{ _("Hide every edit affordance in the NFS tab (add/edit/delete/import). Useful when /etc/exports (or the configured file) is owned externally and Cockpit is only meant to visualize.") }}
+          </span>
         </template>
       </ToggleSwitch>
       <div class="text-header">iSCSI</div>
@@ -149,10 +165,18 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
           :options="tabVisibilityOptions"
         />
       </InputLabelWrapper>
-      <ToggleSwitch v-model="tempUserSettings.iscsi.readOnly">
+      <ToggleSwitch
+        v-model="tempUserSettings.iscsi.readOnly"
+        :disabled="tempUserSettings.iscsi.readOnlyLocked"
+      >
         {{ _("Read-only mode") }}
         <template #description>
-          {{ _("Hide top-level edit affordances across the iSCSI sub-screens. iSCSI is composed of many screens (portals, initiator groups, LUNs, CHAP, …); this flag gates their primary add/edit/delete buttons.") }}
+          <span v-if="tempUserSettings.iscsi.readOnlyLocked">
+            {{ _("Locked: this value is pinned via /etc/cockpit-file-sharing.conf.json (iscsi.readOnlyLocked = true). Edit the file to change it.") }}
+          </span>
+          <span v-else>
+            {{ _("Hide top-level edit affordances across the iSCSI sub-screens. iSCSI is composed of many screens (portals, initiator groups, LUNs, CHAP, …); this flag gates their primary add/edit/delete buttons.") }}
+          </span>
         </template>
       </ToggleSwitch>
        <div class="text-header">S3</div>

--- a/file-sharing/src/common/ui/UserSettingsView.vue
+++ b/file-sharing/src/common/ui/UserSettingsView.vue
@@ -90,6 +90,12 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
           :options="tabVisibilityOptions"
         />
       </InputLabelWrapper>
+      <ToggleSwitch v-model="tempUserSettings.samba.readOnly">
+        {{ _("Read-only mode") }}
+        <template #description>
+          {{ _("Hide every edit affordance in the Samba tab (add/edit/delete/import). Useful when the Samba config is owned externally (config-as-code, Ansible, manual edits) and Cockpit is only meant to visualize.") }}
+        </template>
+      </ToggleSwitch>
       <div class="text-header">NFS</div>
       <InputLabelWrapper>
         <template #label>
@@ -107,6 +113,12 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
         </template>
         <SelectMenu v-model="tempUserSettings.nfs.tabVisibility" :options="tabVisibilityOptions" />
       </InputLabelWrapper>
+      <ToggleSwitch v-model="tempUserSettings.nfs.readOnly">
+        {{ _("Read-only mode") }}
+        <template #description>
+          {{ _("Hide every edit affordance in the NFS tab (add/edit/delete/import). Useful when /etc/exports (or the configured file) is owned externally and Cockpit is only meant to visualize.") }}
+        </template>
+      </ToggleSwitch>
       <div class="text-header">iSCSI</div>
       <InputLabelWrapper>
         <template #label>
@@ -137,6 +149,12 @@ const tabVisibilityOptions: SelectMenuOption<TabVisibility>[] = [
           :options="tabVisibilityOptions"
         />
       </InputLabelWrapper>
+      <ToggleSwitch v-model="tempUserSettings.iscsi.readOnly">
+        {{ _("Read-only mode") }}
+        <template #description>
+          {{ _("Hide top-level edit affordances across the iSCSI sub-screens. iSCSI is composed of many screens (portals, initiator groups, LUNs, CHAP, …); this flag gates their primary add/edit/delete buttons.") }}
+        </template>
+      </ToggleSwitch>
        <div class="text-header">S3</div>
              <InputLabelWrapper>
         <template #label>

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -12,6 +12,13 @@ export type UserSettings = {
      */
     confPath: string;
     tabVisibility: TabVisibility;
+    /**
+     * When true, hide every edit affordance in the tab (add/edit/delete/import).
+     * Read-only operations (view, export) stay available. For deployments where
+     * the config is owned externally (e.g. config-as-code, Ansible, manual edits
+     * to /etc/samba/smb.conf) and Cockpit is only meant to visualize.
+     */
+    readOnly: boolean;
   };
   /**
    * NFS-specific settings
@@ -22,6 +29,12 @@ export type UserSettings = {
      */
     confPath: string;
     tabVisibility: TabVisibility;
+    /**
+     * When true, hide every edit affordance in the tab (add/edit/delete/import).
+     * Read-only operations (view, export) stay available. For deployments where
+     * /etc/exports (or the configured file) is owned externally.
+     */
+    readOnly: boolean;
   };
   s3: {
 
@@ -39,6 +52,12 @@ export type UserSettings = {
     clusteredServer: boolean;
     subnetMask: number;
     tabVisibility: TabVisibility;
+    /**
+     * When true, hide every edit affordance in the tab. iSCSI consists of many
+     * sub-screens (portals, initiator groups, LUNs, CHAP, …); this flag gates
+     * their primary add/edit/delete buttons at the screen level.
+     */
+    readOnly: boolean;
   };
  
   /**
@@ -55,10 +74,12 @@ const defaultSettings = (): UserSettings => ({
   samba: {
     confPath: "/etc/samba/smb.conf",
     tabVisibility: "auto",
+    readOnly: false,
   },
   nfs: {
     confPath: "/etc/exports.d/cockpit-file-sharing.exports",
     tabVisibility: "auto",
+    readOnly: false,
   },
   s3: {
     tabVisibility: "auto",
@@ -70,6 +91,7 @@ const defaultSettings = (): UserSettings => ({
     clusteredServer: false,
     subnetMask: 16,
     tabVisibility: "auto",
+    readOnly: false,
   },
   includeSystemAccounts: false,
   includeDomainAccounts: false,
@@ -92,10 +114,13 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
           samba: {
             confPath: contents.samba?.confPath || defaultSettings().samba.confPath,
             tabVisibility: contents.samba?.tabVisibility || defaultSettings().samba.tabVisibility,
+            // `??` not `||`: false is the default + a valid user choice.
+            readOnly: contents.samba?.readOnly ?? defaultSettings().samba.readOnly,
           },
           nfs: {
             confPath: contents.nfs?.confPath || defaultSettings().nfs.confPath,
             tabVisibility: contents.nfs?.tabVisibility || defaultSettings().nfs.tabVisibility,
+            readOnly: contents.nfs?.readOnly ?? defaultSettings().nfs.readOnly,
           },
           s3: {
             tabVisibility: contents.s3?.tabVisibility || defaultSettings().s3.tabVisibility,
@@ -110,6 +135,7 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
               defaultSettings().iscsi.clusteredServerChecked,
             subnetMask: contents.iscsi?.subnetMask || defaultSettings().iscsi.subnetMask,
             tabVisibility: contents.iscsi?.tabVisibility || defaultSettings().iscsi.tabVisibility,
+            readOnly: contents.iscsi?.readOnly ?? defaultSettings().iscsi.readOnly,
           },
           includeSystemAccounts:
             contents.includeSystemAccounts ?? defaultSettings().includeSystemAccounts,

--- a/file-sharing/src/common/user-settings.ts
+++ b/file-sharing/src/common/user-settings.ts
@@ -19,6 +19,13 @@ export type UserSettings = {
      * to /etc/samba/smb.conf) and Cockpit is only meant to visualize.
      */
     readOnly: boolean;
+    /**
+     * When true, the read-only toggle in the user settings UI becomes
+     * non-interactive (still shown, current value still applied). Lets admins
+     * pin the value via /etc/cockpit-file-sharing.conf.json (Ansible / Puppet /
+     * shell edit) and prevent end-users from undoing it in the UI.
+     */
+    readOnlyLocked: boolean;
   };
   /**
    * NFS-specific settings
@@ -35,6 +42,10 @@ export type UserSettings = {
      * /etc/exports (or the configured file) is owned externally.
      */
     readOnly: boolean;
+    /**
+     * Admin-lock for the read-only toggle. See samba.readOnlyLocked.
+     */
+    readOnlyLocked: boolean;
   };
   s3: {
 
@@ -58,6 +69,10 @@ export type UserSettings = {
      * their primary add/edit/delete buttons at the screen level.
      */
     readOnly: boolean;
+    /**
+     * Admin-lock for the read-only toggle. See samba.readOnlyLocked.
+     */
+    readOnlyLocked: boolean;
   };
  
   /**
@@ -75,11 +90,13 @@ const defaultSettings = (): UserSettings => ({
     confPath: "/etc/samba/smb.conf",
     tabVisibility: "auto",
     readOnly: false,
+    readOnlyLocked: false,
   },
   nfs: {
     confPath: "/etc/exports.d/cockpit-file-sharing.exports",
     tabVisibility: "auto",
     readOnly: false,
+    readOnlyLocked: false,
   },
   s3: {
     tabVisibility: "auto",
@@ -92,6 +109,7 @@ const defaultSettings = (): UserSettings => ({
     subnetMask: 16,
     tabVisibility: "auto",
     readOnly: false,
+    readOnlyLocked: false,
   },
   includeSystemAccounts: false,
   includeDomainAccounts: false,
@@ -116,11 +134,14 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             tabVisibility: contents.samba?.tabVisibility || defaultSettings().samba.tabVisibility,
             // `??` not `||`: false is the default + a valid user choice.
             readOnly: contents.samba?.readOnly ?? defaultSettings().samba.readOnly,
+            readOnlyLocked:
+              contents.samba?.readOnlyLocked ?? defaultSettings().samba.readOnlyLocked,
           },
           nfs: {
             confPath: contents.nfs?.confPath || defaultSettings().nfs.confPath,
             tabVisibility: contents.nfs?.tabVisibility || defaultSettings().nfs.tabVisibility,
             readOnly: contents.nfs?.readOnly ?? defaultSettings().nfs.readOnly,
+            readOnlyLocked: contents.nfs?.readOnlyLocked ?? defaultSettings().nfs.readOnlyLocked,
           },
           s3: {
             tabVisibility: contents.s3?.tabVisibility || defaultSettings().s3.tabVisibility,
@@ -136,6 +157,8 @@ const configFileReadPromise = new Promise<Ref<UserSettings>>((resolve) => {
             subnetMask: contents.iscsi?.subnetMask || defaultSettings().iscsi.subnetMask,
             tabVisibility: contents.iscsi?.tabVisibility || defaultSettings().iscsi.tabVisibility,
             readOnly: contents.iscsi?.readOnly ?? defaultSettings().iscsi.readOnly,
+            readOnlyLocked:
+              contents.iscsi?.readOnlyLocked ?? defaultSettings().iscsi.readOnlyLocked,
           },
           includeSystemAccounts:
             contents.includeSystemAccounts ?? defaultSettings().includeSystemAccounts,

--- a/file-sharing/src/tabs/iSCSI/ui/ISCSITabMain.vue
+++ b/file-sharing/src/tabs/iSCSI/ui/ISCSITabMain.vue
@@ -27,6 +27,7 @@ import type { VirtualDevice } from "@/tabs/iSCSI/types/VirtualDevice";
 import ConfigurationEditor from "@/tabs/iSCSI/ui/screens/config/ConfigurationEditor.vue";
 import { ISCSIDriverClusteredServer } from "@/tabs/iSCSI/types/drivers/ISCSIDriverClusteredServer";
 import { useUserSettings } from "@/common/user-settings";
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
 import { ResultAsync } from "neverthrow";
 import type { ISCSIDriver } from "@/tabs/iSCSI/types/drivers/ISCSIDriver";
 import type { Target } from "@/tabs/iSCSI/types/Target";
@@ -40,8 +41,17 @@ const OLD_CONF_PATH = "/etc/scst/cockpit-iscsi.conf";
 const NEW_CONF_PATH = "/etc/scst.conf";
 const has45DrivesOcfProvider = ref(false);
 provide("has45DrivesOcfProvider", has45DrivesOcfProvider);
-const canEdit = computed(() => !useUserSettings().value.iscsi.clusteredServer || has45DrivesOcfProvider.value);
+// iscsi.readOnly is the user-facing kill switch (settings modal); it composes
+// with the existing clustered/OCF-provider gate so every screen's canEditIscsi
+// inject already respects the new flag without per-screen changes.
+const canEdit = computed(() =>
+  !useUserSettings().value.iscsi.readOnly &&
+  (!useUserSettings().value.iscsi.clusteredServer || has45DrivesOcfProvider.value)
+);
 provide("canEditIscsi", canEdit);
+// Also publish under the standard injection key so future iSCSI components
+// can use the same pattern as the NFS/Samba tabs.
+provide(readOnlyInjectionKey, computed(() => useUserSettings().value.iscsi.readOnly));
 
 // Function to check and move the configuration file
 const moveConfigFileIfNeeded = async () => {

--- a/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
+++ b/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
@@ -18,10 +18,11 @@ import {
   Table,
   type ValidationResult,
 } from "@45drives/houston-common-ui";
-import { defineProps, defineEmits, computed, ref } from "vue";
+import { defineProps, defineEmits, computed, inject, ref } from "vue";
 import ShareDirectoryInputAndOptions from "@/common/ui/ShareDirectoryInputAndOptions.vue";
 import { PlusIcon, TrashIcon } from "@heroicons/vue/20/solid";
 import { getServer, FileSystemNode } from "@45drives/houston-common-lib";
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
 
 import { NFSExportParser } from "@/tabs/nfs/exports-parser";
 
@@ -47,6 +48,11 @@ const emit = defineEmits<{
 }>();
 
 const globalProcessingState = useGlobalProcessingState();
+
+// Read-only mode hides write affordances and disables inputs so the editor
+// becomes a details view. Provided by the tab's TabMain (see NFSTabMain.vue);
+// defaults to false for standalone test mounts.
+const readOnly = inject(readOnlyInjectionKey, computed(() => false));
 
 const exportConfig = computed<NFSExport>(() =>
   props.newExport ? newNFSExport() : props.nfsExport
@@ -206,7 +212,11 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
 <template>
   <div class="space-y-content">
     <div v-if="newExport" class="text-header">{{ _("New Share") }}</div>
-    <div class="space-y-content">
+    <!-- fieldset[disabled] cascades to every form control inside, including
+         third-party InputField/SelectMenu components, without each needing
+         a :disabled prop. Hidden buttons (Add/Remove client, Apply) are
+         additionally v-if'd off so they don't take layout space. -->
+    <fieldset :disabled="readOnly" class="space-y-content !m-0 !p-0 border-0">
       <div>
         <ShareDirectoryInputAndOptions
           v-model:path="tempExportConfig.path"
@@ -260,7 +270,7 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
               <th scope="col">{{ _("Settings") }}</th>
               <th scope="col" class="flex flex-row justify-end">
                 <span class="sr-only">{{ _("Delete") }}</span>
-                <button @click="() => addClient()">
+                <button v-if="!readOnly" @click="() => addClient()">
                   <span class="sr-only">{{ _("Add new client") }}</span>
                   <PlusIcon class="size-icon icon-default" />
                 </button>
@@ -282,6 +292,7 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
                 <td>
                   <div class="button-group-row justify-end">
                     <button
+                      v-if="!readOnly"
                       :disabled="tempExportConfig.clients.length <= 1"
                       :title="_('Remove client')"
                       @click="() => removeClient(index)"
@@ -318,9 +329,10 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
             }
           "
         >
-          {{ _("Cancel") }}
+          {{ readOnly ? _("Close") : _("Cancel") }}
         </button>
         <button
+          v-if="!readOnly"
           class="btn btn-primary"
           @click="$emit('apply', tempExportConfig)"
           :disabled="
@@ -332,6 +344,6 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
           {{ _("Apply") }}
         </button>
       </div>
-    </div>
+    </fieldset>
   </div>
 </template>

--- a/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
+++ b/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
@@ -317,33 +317,36 @@ const shareDirectoryInputAndOptionsRef = ref<InstanceType<
           {{ validationScope.isValid() ? exportPreview : "" }}
         </div>
       </InputLabelWrapper>
-
-      <div class="button-group-row justify-end grow">
-        <button
-          class="btn btn-secondary"
-          @click="
-            () => {
-              resetChanges();
-              shareDirectoryInputAndOptionsRef?.resetChanges?.();
-              $emit('cancel');
-            }
-          "
-        >
-          {{ readOnly ? _("Close") : _("Cancel") }}
-        </button>
-        <button
-          v-if="!readOnly"
-          class="btn btn-primary"
-          @click="$emit('apply', tempExportConfig)"
-          :disabled="
-            !validationScope.isValid() ||
-            (!modified && !shareDirectoryOptionsModified) ||
-            globalProcessingState !== 0
-          "
-        >
-          {{ _("Apply") }}
-        </button>
-      </div>
     </fieldset>
+
+    <!-- Action row outside the fieldset so Close stays clickable in
+         read-only mode (the fieldset's disabled cascade would otherwise
+         trap the user in the details view). Apply is v-if'd off anyway. -->
+    <div class="button-group-row justify-end grow">
+      <button
+        class="btn btn-secondary"
+        @click="
+          () => {
+            resetChanges();
+            shareDirectoryInputAndOptionsRef?.resetChanges?.();
+            $emit('cancel');
+          }
+        "
+      >
+        {{ readOnly ? _("Close") : _("Cancel") }}
+      </button>
+      <button
+        v-if="!readOnly"
+        class="btn btn-primary"
+        @click="$emit('apply', tempExportConfig)"
+        :disabled="
+          !validationScope.isValid() ||
+          (!modified && !shareDirectoryOptionsModified) ||
+          globalProcessingState !== 0
+        "
+      >
+        {{ _("Apply") }}
+      </button>
+    </div>
   </div>
 </template>

--- a/file-sharing/src/tabs/nfs/ui/NFSExportListView.vue
+++ b/file-sharing/src/tabs/nfs/ui/NFSExportListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineProps, nextTick } from "vue";
+import { ref, computed, defineProps, inject, nextTick, watch } from "vue";
 import type { NFSExport } from "@/tabs/nfs/data-types";
 import {
   CardContainer,
@@ -8,7 +8,8 @@ import {
   Table,
 } from "@45drives/houston-common-ui";
 import NFSExportEditor from "@/tabs/nfs/ui/NFSExportEditor.vue";
-import { PencilSquareIcon, TrashIcon, PlusIcon } from "@heroicons/vue/20/solid";
+import { PencilSquareIcon, EyeIcon, TrashIcon, PlusIcon } from "@heroicons/vue/20/solid";
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
 
 const _ = cockpit.gettext;
 
@@ -22,7 +23,18 @@ const emit = defineEmits<{
   (e: "removeExport", nfsExport: NFSExport, callback?: () => void): void;
 }>();
 
+// Default ref(false) handles standalone test mounts that aren't under a provider.
+const readOnly = inject(readOnlyInjectionKey, computed(() => false));
+
 const showNewExportEditor = ref(false);
+
+// Auto-close any open "new share" form when read-only is toggled on, so the
+// editor doesn't get orphaned (the `+` button is hidden, leaving no obvious
+// way to close it otherwise). Per-row editors don't need this — their inputs
+// just become disabled and the Apply button hides reactively.
+watch(readOnly, (isReadOnly) => {
+  if (isReadOnly) showNewExportEditor.value = false;
+});
 
 const allExportedPaths = computed(() => props.nfsExports.map(({ path }) => path));
 </script>
@@ -45,7 +57,7 @@ const allExportedPaths = computed(() => props.nfsExports.map(({ path }) => path)
     </Disclosure>
 
     <Table
-      :emptyText="_('No shares. Click \'+\' to add one.')"
+      :emptyText="readOnly ? _('No shares configured.') : _('No shares. Click \'+\' to add one.')"
       noScroll
       class="sm:rounded-lg sm:shadow sm:border sm:border-default sm:overflow-hidden"
     >
@@ -54,8 +66,8 @@ const allExportedPaths = computed(() => props.nfsExports.map(({ path }) => path)
           <th scope="col">{{ _("Path") }}</th>
           <th scope="col">{{ _("Comment") }}</th>
           <th scope="col" class="flex flex-row justify-end">
-            <span class="sr-only">{{ _("Edit/Delete") }}</span>
-            <button @click="showNewExportEditor = !showNewExportEditor">
+            <span class="sr-only">{{ readOnly ? _("View") : _("Edit/Delete") }}</span>
+            <button v-if="!readOnly" @click="showNewExportEditor = !showNewExportEditor">
               <span class="sr-only">{{ _("Add new share") }}</span>
               <PlusIcon class="size-icon icon-default" />
             </button>
@@ -76,11 +88,16 @@ const allExportedPaths = computed(() => props.nfsExports.map(({ path }) => path)
                 {{ nfsExport.comment }}
               </td>
               <td class="button-group-row justify-end">
-                <button @click="setShowEditor(!showEditor)">
-                  <span class="sr-only">Edit</span>
-                  <PencilSquareIcon class="size-icon icon-default" />
+                <button
+                  @click="setShowEditor(!showEditor)"
+                  :title="readOnly ? _('View details') : _('Edit')"
+                >
+                  <span class="sr-only">{{ readOnly ? _("View") : _("Edit") }}</span>
+                  <EyeIcon v-if="readOnly" class="size-icon icon-default" />
+                  <PencilSquareIcon v-else class="size-icon icon-default" />
                 </button>
                 <button
+                  v-if="!readOnly"
                   @click="
                     // for fileystem-specific hooks:
                     setShowEditor(true);

--- a/file-sharing/src/tabs/nfs/ui/NFSTabMain.vue
+++ b/file-sharing/src/tabs/nfs/ui/NFSTabMain.vue
@@ -9,7 +9,11 @@ import {
 } from "@45drives/houston-common-ui";
 import { Upload, /* Download, */ getServerCluster, server, Command } from "@45drives/houston-common-lib";
 import { computed, provide, ref } from "vue";
-import { serverClusterInjectionKey, cephClientNameInjectionKey } from "@/common/injectionKeys";
+import {
+  serverClusterInjectionKey,
+  cephClientNameInjectionKey,
+  readOnlyInjectionKey,
+} from "@/common/injectionKeys";
 
 import { useUserSettings } from "@/common/user-settings";
 import { getNFSManager } from "@/tabs/nfs/nfs-manager";
@@ -25,6 +29,9 @@ const cluster = getServerCluster("pcs");
 provide(serverClusterInjectionKey, cluster);
 const cephClientName = ref<`client.${string}`>("client.nfs");
 provide(cephClientNameInjectionKey, cephClientName);
+
+const readOnly = computed(() => userSettings.value.nfs.readOnly);
+provide(readOnlyInjectionKey, readOnly);
 
 const nfsManager = computed(() => {
   const exportsPath = userSettings.value.nfs.confPath;
@@ -124,7 +131,7 @@ const actions = wrapActions({
         {{ _("Import/Export Config") }}
       </template>
       <div class="button-group-row flex-wrap">
-        <button class="btn btn-primary" @click="actions.importConfig">
+        <button v-if="!readOnly" class="btn btn-primary" @click="actions.importConfig">
           {{ _("Import") }}
         </button>
         <button class="btn btn-primary" @click="actions.exportConfig">

--- a/file-sharing/src/tabs/samba/ui/GlobalConfigEditor.vue
+++ b/file-sharing/src/tabs/samba/ui/GlobalConfigEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect, computed } from "vue";
+import { inject, ref, watchEffect, computed } from "vue";
 import {
   InputField,
   InputLabelWrapper,
@@ -15,6 +15,9 @@ import {
 import { KeyValueSyntax, SambaGlobalConfig } from "@45drives/houston-common-lib";
 import { BooleanKeyValueSuite } from "@/tabs/samba/ui/BooleanKeyValueSuite"; // TODO: move to common-ui
 import ManageSambaPasswordsButton from '@/tabs/samba/ui/ManageSambaPasswordsButton.vue';
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
+
+const readOnly = inject(readOnlyInjectionKey, computed(() => false));
 
 const _ = cockpit.gettext;
 
@@ -67,6 +70,7 @@ const logLevelOptions: SelectMenuOption<number>[] = [5, 4, 3, 2, 1, 0].map((n) =
     </template>
 
     <div v-if="tempGlobalConfig" class="space-y-content">
+    <fieldset :disabled="readOnly" class="space-y-content !m-0 !p-0 border-0">
       <InputLabelWrapper>
         <template #label>
           {{ _("Server Description") }}
@@ -103,21 +107,28 @@ const logLevelOptions: SelectMenuOption<number>[] = [5, 4, 3, 2, 1, 0].map((n) =
           </template>
         </ToggleSwitch>
       </ToggleSwitchGroup>
+    </fieldset>
+      <!-- Disclosure lives outside the fieldset so its toggle button stays
+           interactive in read-only mode (read-only operators still want to
+           inspect what's in Advanced). The inner ParsedTextArea sits in its
+           own fieldset so editing is still blocked. -->
       <Disclosure v-model:show="revealAdvancedTextarea">
         <template v-slot:label>
           {{ _("Advanced") }}
         </template>
-        <ParsedTextArea
-          :parser="KeyValueSyntax({ trailingNewline: false })"
-          v-model="tempGlobalConfig.advancedOptions"
-        />
+        <fieldset :disabled="readOnly" class="!m-0 !p-0 border-0">
+          <ParsedTextArea
+            :parser="KeyValueSyntax({ trailingNewline: false })"
+            v-model="tempGlobalConfig.advancedOptions"
+          />
+        </fieldset>
       </Disclosure>
     </div>
 
     <template v-slot:footer>
       <div class="button-group-row justify-between grow flex-wrap">
-        <ManageSambaPasswordsButton />
-        <div class="button-group-row">
+        <ManageSambaPasswordsButton v-if="!readOnly" />
+        <div v-if="!readOnly" class="button-group-row">
           <button class="btn btn-secondary" @click="resetChanges" v-if="modified">
             {{ _("Cancel") }}
           </button>

--- a/file-sharing/src/tabs/samba/ui/SambaTabMain.vue
+++ b/file-sharing/src/tabs/samba/ui/SambaTabMain.vue
@@ -26,7 +26,11 @@ import GlobalConfigEditor from "./GlobalConfigEditor.vue";
 import ShareListView from "@/tabs/samba/ui/ShareListView.vue";
 
 import { provide, ref, watch, computed } from "vue";
-import { serverClusterInjectionKey, cephClientNameInjectionKey } from "@/common/injectionKeys";
+import {
+  serverClusterInjectionKey,
+  cephClientNameInjectionKey,
+  readOnlyInjectionKey,
+} from "@/common/injectionKeys";
 
 import { HookedSambaManager as SambaManager } from "@/tabs/samba/samba-manager";
 import { okAsync } from "neverthrow";
@@ -38,6 +42,9 @@ const _ = cockpit.gettext;
 const userSettings = useUserSettings();
 
 const smbConfPath = computed(() => userSettings.value.samba.confPath);
+
+const readOnly = computed(() => userSettings.value.samba.readOnly);
+provide(readOnlyInjectionKey, readOnly);
 
 provide(serverClusterInjectionKey, getServerCluster("ctdb"));
 const cephClientName = ref<`client.${string}`>("client.samba");
@@ -126,6 +133,10 @@ const checkIfSmbConfIncludesRegistry = (smbConfPath: string) =>
     .andThen((sm) => sm.checkIfSambaConfIncludesRegistry(smbConfPath))
     .map((smbConfHasIncludeRegistry) => {
       if (!smbConfHasIncludeRegistry) {
+        // In read-only mode we don't manage shares ourselves, so the misconfig
+        // notification + Fix-now action are noise (and the action would write
+        // to smb.conf — forbidden when the user opted out of edits).
+        if (readOnly.value) return;
         pushNotification(
           new Notification(
             _("Samba is Misconfigured"),
@@ -235,13 +246,14 @@ watch(smbConfPath, () => actions.checkIfSmbConfIncludesRegistry(smbConfPath.valu
         {{ _("Import/Export Config") }}
       </template>
       <div class="button-group-row flex-wrap">
-        <button class="btn btn-primary" @click="actions.importConfig">
+        <button v-if="!readOnly" class="btn btn-primary" @click="actions.importConfig">
           {{ _("Import") }}
         </button>
         <button class="btn btn-primary" @click="actions.exportConfig">
           {{ _("Export") }}
         </button>
         <button
+          v-if="!readOnly"
           class="btn btn-secondary inline-flex flex-row items-center gap-1"
           @click="actions.importFromSmbConf(smbConfPath)"
         >

--- a/file-sharing/src/tabs/samba/ui/ShareEditor.vue
+++ b/file-sharing/src/tabs/samba/ui/ShareEditor.vue
@@ -3,12 +3,14 @@ import {
   defineProps,
   computed,
   defineEmits,
+  inject,
   ref,
   watchEffect,
   onMounted,
   type Ref,
   watch,
 } from "vue";
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
 import {
   InputField,
   ToggleSwitch,
@@ -51,6 +53,10 @@ const emit = defineEmits<{
 }>();
 
 const globalProcessingState = useGlobalProcessingState();
+
+// Named `tabReadOnly` to avoid shadowing `tempShareConfig.readOnly`, which is
+// the SMB share's own "read only = yes" config field (entirely unrelated).
+const tabReadOnly = inject(readOnlyInjectionKey, computed(() => false));
 
 const shareConf = computed<SambaShareConfig>(() =>
   props.newShare ? SambaShareConfig.makeNew() : props.share
@@ -182,7 +188,7 @@ mutuallyExclusive(
 <template>
   <div class="space-y-content">
     <div v-if="newShare" class="text-header">{{ _("New Share") }}</div>
-    <div class="space-y-content">
+    <fieldset :disabled="tabReadOnly" class="space-y-content !m-0 !p-0 border-0">
       <InputLabelWrapper>
         <template #label>
           {{ _("Share Name") }}
@@ -247,14 +253,21 @@ mutuallyExclusive(
         </ToggleSwitch>
       </ToggleSwitchGroup>
 
+    </fieldset>
+      <!-- Disclosure outside the fieldset so its toggle button stays
+           interactive in read-only mode (operators still want to inspect
+           Advanced). Inner ParsedTextArea is wrapped in its own disabled
+           fieldset to block edits. -->
       <Disclosure v-model:show="revealAdvancedTextarea">
         <template v-slot:label>
           {{ _("Advanced") }}
         </template>
-        <ParsedTextArea
-          :parser="KeyValueSyntax({ trailingNewline: false })"
-          v-model="tempShareConfig.advancedOptions"
-        />
+        <fieldset :disabled="tabReadOnly" class="!m-0 !p-0 border-0">
+          <ParsedTextArea
+            :parser="KeyValueSyntax({ trailingNewline: false })"
+            v-model="tempShareConfig.advancedOptions"
+          />
+        </fieldset>
       </Disclosure>
 
       <div class="button-group-row justify-end grow">
@@ -268,9 +281,10 @@ mutuallyExclusive(
             }
           "
         >
-          {{ _("Cancel") }}
+          {{ tabReadOnly ? _("Close") : _("Cancel") }}
         </button>
         <button
+          v-if="!tabReadOnly"
           class="btn btn-primary"
           @click="$emit('apply', tempShareConfig)"
           :disabled="
@@ -282,6 +296,5 @@ mutuallyExclusive(
           {{ _("Apply") }}
         </button>
       </div>
-    </div>
   </div>
 </template>

--- a/file-sharing/src/tabs/samba/ui/ShareListView.vue
+++ b/file-sharing/src/tabs/samba/ui/ShareListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineProps, nextTick } from "vue";
+import { ref, computed, defineProps, inject, nextTick, watch } from "vue";
 import {
   CardContainer,
   Disclosure,
@@ -8,8 +8,9 @@ import {
 } from "@45drives/houston-common-ui";
 import { PlusIcon } from "@heroicons/vue/20/solid";
 import ShareEditor from "@/tabs/samba/ui/ShareEditor.vue";
-import { PencilSquareIcon, TrashIcon } from "@heroicons/vue/20/solid";
+import { EyeIcon, PencilSquareIcon, TrashIcon } from "@heroicons/vue/20/solid";
 import { SambaShareConfig } from "@45drives/houston-common-lib";
+import { readOnlyInjectionKey } from "@/common/injectionKeys";
 
 const _ = cockpit.gettext;
 
@@ -23,7 +24,17 @@ const emit = defineEmits<{
   (e: "removeShare", share: SambaShareConfig, callback?: () => void): void;
 }>();
 
+const readOnly = inject(readOnlyInjectionKey, computed(() => false));
+
 const showNewShareEditor = ref(false);
+
+// Auto-close any open "new share" form when read-only is toggled on, so the
+// editor doesn't get orphaned (the `+` button is hidden, leaving no obvious
+// way to close it). Per-row editors don't need this — their inputs become
+// disabled and the Apply button hides reactively.
+watch(readOnly, (isReadOnly) => {
+  if (isReadOnly) showNewShareEditor.value = false;
+});
 
 const shareNames = computed(() => props.shares.map((s) => s.name));
 </script>
@@ -46,7 +57,7 @@ const shareNames = computed(() => props.shares.map((s) => s.name));
     </Disclosure>
 
     <Table
-      :emptyText="_('No shares. Click \'+\' to add one.')"
+      :emptyText="readOnly ? _('No shares configured.') : _('No shares. Click \'+\' to add one.')"
       noScroll
       class="sm:rounded-lg sm:shadow sm:border sm:border-default sm:overflow-hidden"
     >
@@ -56,8 +67,8 @@ const shareNames = computed(() => props.shares.map((s) => s.name));
           <th scope="col">{{ _("Path") }}</th>
           <th scope="col">{{ _("Description") }}</th>
           <th scope="col" class="flex flex-row justify-end">
-            <span class="sr-only">{{ _("Edit/Delete") }}</span>
-            <button @click="showNewShareEditor = !showNewShareEditor">
+            <span class="sr-only">{{ readOnly ? _("View") : _("Edit/Delete") }}</span>
+            <button v-if="!readOnly" @click="showNewShareEditor = !showNewShareEditor">
               <span class="sr-only">{{ _("Add new share") }}</span>
               <PlusIcon class="size-icon icon-default" />
             </button>
@@ -82,11 +93,16 @@ const shareNames = computed(() => props.shares.map((s) => s.name));
                 {{ share.description }}
               </td>
               <td class="button-group-row justify-end">
-                <button @click="setShowEditor(!showEditor)">
-                  <span class="sr-only">Edit</span>
-                  <PencilSquareIcon class="size-icon icon-default" />
+                <button
+                  @click="setShowEditor(!showEditor)"
+                  :title="readOnly ? _('View details') : _('Edit')"
+                >
+                  <span class="sr-only">{{ readOnly ? _("View") : _("Edit") }}</span>
+                  <EyeIcon v-if="readOnly" class="size-icon icon-default" />
+                  <PencilSquareIcon v-else class="size-icon icon-default" />
                 </button>
                 <button
+                  v-if="!readOnly"
                   @click="
                     // for fileystem-specific hooks:
                     setShowEditor(true);


### PR DESCRIPTION
## What this adds

A per-tab **Read-only mode** toggle for Samba, NFS, and iSCSI. When turned on for a tab, every edit affordance in that tab disappears (add / edit / delete / import) and form inputs become non-editable; read-only operations (view, export) stay available. The toggle lives in *Settings → \<tab name\> → Read-only mode*; defaults to off everywhere; existing behavior is preserved.

A companion **`*.readOnlyLocked`** field lets admins pin the value via `/etc/cockpit-file-sharing.conf.json` (Ansible / Puppet / shell). When set, the UI toggle stays visible but becomes non-interactive, with a discoverable note explaining where the value comes from — turning read-only mode from a *user preference* into a *policy*.

> **Pairs well with [#185 — Connected Clients tab](https://github.com/45Drives/cockpit-file-sharing/pull/185)**: that PR adds a live view of who's actually connected to Samba/NFS right now; this PR makes the underlying share-configuration view safe for monitoring-focused operators who can't risk an accidental edit. Together they turn cockpit-file-sharing into a first-class monitoring tool for hosts whose share config is owned outside Cockpit. The two are orthogonal and land cleanly in either order.

### Example: locking read-only mode via the config file

Below is a minimal `/etc/cockpit-file-sharing.conf.json` that pins NFS to read-only mode and prevents the UI from undoing it. Samba/iSCSI keys are omitted (defaults apply); add them with the same shape if you want to lock those too.

```json
{
  "nfs": {
    "readOnly": true,
    "readOnlyLocked": true
  }
}
```

Equivalent one-liner via `jq` (preserves any other settings already in the file):

```bash
sudo jq '.nfs.readOnly = true | .nfs.readOnlyLocked = true' \
  /etc/cockpit-file-sharing.conf.json | sudo tee /etc/cockpit-file-sharing.conf.json.new \
  && sudo mv /etc/cockpit-file-sharing.conf.json.new /etc/cockpit-file-sharing.conf.json
```

Ansible:

```yaml
- name: Pin NFS tab to read-only mode in cockpit-file-sharing
  ansible.builtin.copy:
    dest: /etc/cockpit-file-sharing.conf.json
    owner: root
    group: root
    mode: "0644"
    content: |
      {
        "nfs": {
          "readOnly": true,
          "readOnlyLocked": true
        }
      }
```

After the file changes, Cockpit picks up the new value on the next page load (the settings file is watched). The user-settings modal will show the NFS read-only ToggleSwitch as non-interactive with a note indicating the value is pinned via the config file.

### Example: read-only view of an externally-managed file (e.g. `/etc/exports`)

Composing the read-only mode with the existing `nfs.confPath` setting lets you point cockpit at the actual system file managed via CLI/Ansible/etc., turning the NFS tab into a safe visualization of that file. No code changes required — both settings already exist; read-only mode just makes the combination safe.

```json
{
  "nfs": {
    "confPath": "/etc/exports",
    "readOnly": true,
    "readOnlyLocked": true
  }
}
```

What this gets you:

- The Share Configuration table reads from `/etc/exports` directly — what you edit on the CLI is what appears in the UI.
- Cockpit physically can't touch the file: every UI write path is hidden by `readOnly: true`.
- The Read-only toggle in Settings is non-interactive thanks to `readOnlyLocked: true`, so a user can't accidentally re-enable edits.
- CLI workflow stays completely unchanged: edit `/etc/exports` with vim/Ansible/sed, run `sudo exportfs -ra`, refresh the browser — no Cockpit involvement.

Same shape works for `samba.confPath` → `/etc/samba/smb.conf` (with the registry-include caveat from upstream's existing docs), and is a one-line config for anyone whose config is already owned outside Cockpit.

**Why it matters**

This closes a gap for deployments where the underlying config is owned externally and Cockpit is only meant to visualize:

- **Config-as-code shops**: `/etc/exports`, `/etc/samba/smb.conf` are managed by Ansible / Puppet / Terraform with a human-readable layout. Today Cockpit's only choices are "hide the whole tab" or "let the UI clobber the file on the next click". Read-only mode is the in-between: the operator sees what's there but can't accidentally invalidate the source of truth.
- **Manual-edit + occasional UI inspect**: same shape, smaller scale — an admin who keeps `/etc/exports` documented with header comments and intentional structure, but wants to glance at the rendered view from time to time.
- **Multi-operator environments** where some users should observe but not change.

The alternative — telling people to set `tabVisibility: "never"` — works but loses the visualization. Read-only mode keeps the visualization without the risk.

---

## Screenshots

### 1. Settings panel — the three new toggles (highlighted in red)
The user settings modal showing the new **Read-only mode** ToggleSwitch under each of Samba, NFS, and iSCSI sections (highlighted). Demonstrates per-tab opt-in — Samba, NFS, and iSCSI are configured independently, not as a single all-or-nothing switch.

<img width="1389" height="904" alt="screenshot-1" src="https://github.com/user-attachments/assets/116c023e-d37b-47da-9951-d6f738528d0d" />

### 2. Samba tab — read-only mode active
The Samba tab with read-only on, share list collapsed. No `+` in the share-config header, no pencil/trash icons in rows. Form fields and edit affordances in the Global Configuration card are absent.

<img width="1332" height="1162" alt="screenshot-2" src="https://github.com/user-attachments/assets/de6ffcdf-75e9-44c2-a002-d6675e2abaab" />

### 3. Samba share — read-only details view
A Samba share row expanded with its editor visible: every input disabled, no Apply button, the action button reads **Close** instead of Cancel. Demonstrates that the editor doubles as a read-only details view in this mode — operators can still inspect what's configured, they just can't change it.

<img width="1213" height="1076" alt="screenshot-3" src="https://github.com/user-attachments/assets/bad5e2ea-1f35-4985-b531-c00df9de2f4d" />

### 4. NFS tab — read-only mode active, reading from `/etc/exports`
The NFS tab in read-only mode, share list collapsed. In this deployment `nfs.confPath` points at `/etc/exports` and `nfs.readOnlyLocked` pins the read-only flag (see the *Example: read-only view of an externally-managed file* section below). The table reflects the real system exports the operator manages via CLI/Ansible — no longer empty, no UI write affordances, no risk of cockpit overwriting the file.

<img width="1350" height="693" alt="screenshot-4" src="https://github.com/user-attachments/assets/0e8909ab-6b76-4e1b-b9e5-6ddf2c4d908c" />

### 5. NFS export — read-only details view
An NFS export row expanded with its editor visible: disabled inputs throughout, no Apply button, no Add/Remove client buttons in the clients table, "Close" instead of "Cancel". Same pattern as Samba — the editor becomes a details view.

<img width="1212" height="859" alt="screenshot-5" src="https://github.com/user-attachments/assets/5479c38f-2068-4ac7-9b53-e8b77bbe28a6" />

---

## How it works

**Settings shape** — six new boolean fields, all default `false`:

```ts
UserSettings.samba.readOnly:       boolean;  // the actual flag
UserSettings.samba.readOnlyLocked: boolean;  // admin-lock for the UI toggle
UserSettings.nfs.readOnly:         boolean;
UserSettings.nfs.readOnlyLocked:   boolean;
UserSettings.iscsi.readOnly:       boolean;
UserSettings.iscsi.readOnlyLocked: boolean;
```

Merge logic uses `??` so a stored `false` is preserved (not overwritten by the default).

**Admin lock** — when `*.readOnlyLocked: true` is set in `/etc/cockpit-file-sharing.conf.json`, the corresponding ToggleSwitch in the user settings modal gets `:disabled="true"` and the description swaps to a "Locked: pinned via ..." note. The lock doesn't affect the *behavior* of the underlying `readOnly` value — that still drives the tab — it just prevents end-users from flipping it back in the UI. Optional and defaults to false, so existing configs and UI-only users see no change.

**Propagation** — each tab's `TabMain.vue` provides its setting as a `ComputedRef<boolean>` under a shared injection key (`readOnlyInjectionKey` in `common/injectionKeys.ts`). Child components inject it and gate write affordances:

| Affordance | Mechanism |
|---|---|
| Add (`+`) button | `v-if="!readOnly"` |
| Pencil → Eye icon swap | `v-if="readOnly"` on `EyeIcon`, `v-else` on `PencilSquareIcon` |
| Trash (Delete) button | `v-if="!readOnly"` |
| Form inputs | wrapping `<fieldset :disabled="readOnly">` cascades to every child form control without per-input prop changes |
| Apply button | `v-if="!readOnly"` |
| Cancel → Close button text | `{{ readOnly ? _("Close") : _("Cancel") }}` |
| Empty-state copy | `readOnly ? _('No shares configured.') : _('No shares. Click "+" to add one.')` |

**Pending "new share" forms** auto-close when the toggle flips on, so they can't get orphaned (no `+` to reopen). Per-row editors don't need explicit toggle handling — their fieldset and button visibility re-evaluate from the same injected ComputedRef, so an open details panel just becomes disabled in place.

**Disclosures stay expandable.** In Samba's Global and Share editors, the *Advanced* disclosure is deliberately lifted outside the outer disabled fieldset, with its inner `ParsedTextArea` wrapped in its own disabled fieldset. The toggle button stays interactive (operators want to inspect advanced fields), but the textarea inside is uneditable. This pattern is reusable for any other "collapsible details" surface.

**Samba misconfig notification suppressed.** The "Samba is Misconfigured / Fix now" toast both annoys read-only operators and would write to `/etc/samba/smb.conf` via its Fix-now action (forbidden when the operator has opted out of edits). Suppressed when `samba.readOnly` is true.

**iSCSI composes with existing gate.** iSCSI already has a per-screen `canEditIscsi` inject used to disable writes in clustered mode without the 45Drives OCF provider; every screen that has create/delete affordances (portals, RBD, LUNs, etc.) already consumes it. `iscsi.readOnly` is composed into the existing `canEdit` computed, so the new flag gets coverage across every consuming screen without per-screen touches:

```ts
const canEdit = computed(() =>
  !useUserSettings().value.iscsi.readOnly &&
  (!useUserSettings().value.iscsi.clusteredServer || has45DrivesOcfProvider.value)
);
```

Also published under the standard `readOnlyInjectionKey` for future iSCSI components that want the same pattern as NFS/Samba.

---

## Trade-offs and explicit non-goals

- **Per-tab, not global.** Each tab opts in independently. Rationale: a sysadmin might manage Samba via Cockpit but pin NFS to config-as-code. An umbrella toggle could be added later as a UI convenience over the three booleans; not done here to keep the PR shape minimal.
- **Naming clash, contained.** `samba.readOnly` (this PR) and `tempShareConfig.readOnly` (the Samba share's own `read only = yes` config field) are unrelated. The injected ref in `ShareEditor.vue` is aliased to `tabReadOnly` to keep the two from shadowing. Documented inline.
- **iSCSI editor inputs not individually wrapped in fieldsets.** The `canEditIscsi` gate already handles the *write* path (create/delete buttons); the per-input "disabled" cascade isn't wired through every iSCSI editor here. In practice the existing gate covers the user-visible affordances. Deeper editor-input wiring can follow if a tester finds a gap.
- **Read-only does NOT hide the tab.** The existing `tabVisibility: "never"` is a stronger setting (tab disappears entirely). Read-only is the visualize-without-edit point on that spectrum.

---

## Compatibility

- **Settings file**: existing `/etc/cockpit-file-sharing.conf.json` files without the new field are read unchanged — defaults apply. New writes include the field. No migration required.
- **Houston-common**: no new components, no new injection patterns outside the local `injectionKeys.ts`. Existing `fieldset[disabled]` cascade is HTML-standard.
- **i18n**: all new user-facing strings (settings labels, descriptions, empty-state text, button labels, ARIA labels) go through `cockpit.gettext`.

---

## Files changed

```
file-sharing/src/common/injectionKeys.ts              (+10 lines: readOnlyInjectionKey)
file-sharing/src/common/user-settings.ts              (+26 lines: type + defaults + merge for nfs/samba/iscsi)
file-sharing/src/common/ui/UserSettingsView.vue       (+18 lines: three toggles)
file-sharing/src/tabs/nfs/ui/NFSTabMain.vue           (+11 lines: provide + Import button gate)
file-sharing/src/tabs/nfs/ui/NFSExportListView.vue    (+~25 lines: inject + button gates + auto-close)
file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue      (+~22 lines: inject + fieldset + button gates)
file-sharing/src/tabs/samba/ui/SambaTabMain.vue       (+~16 lines: provide + button gates + toast suppression)
file-sharing/src/tabs/samba/ui/ShareListView.vue      (+~24 lines: inject + button gates + auto-close)
file-sharing/src/tabs/samba/ui/ShareEditor.vue        (+~13 lines: inject + fieldset + Advanced lift)
file-sharing/src/tabs/samba/ui/GlobalConfigEditor.vue (+~17 lines: inject + fieldset + Advanced lift + footer gates)
file-sharing/src/tabs/iSCSI/ui/ISCSITabMain.vue       (+~11 lines: compose into canEdit + standard inject key)
```

Eleven files, all minimally touched. No new dependencies, no manifest or build pipeline changes.

---

## How to test

```bash
git checkout feat/read-only-mode
make install-local
sudo systemctl restart cockpit.socket  # if needed
```

Then in Cockpit → File Sharing:

1. Open Settings (cog, bottom-right) → toggle on **Read-only mode** under any/all of Samba, NFS, iSCSI → Apply.
2. **NFS** (if enabled): the Share Configuration card shows no `+`/pencil/trash; clicking a row's eye icon opens the editor with every input disabled, no Apply button, Cancel reads "Close".
3. **Samba** (if enabled): same affordance gating; the Global Configuration card disables every input and hides the Manage Samba Passwords button; the Advanced disclosure remains expandable but the textarea inside is disabled.
4. **iSCSI** (if enabled): primary add buttons across the sub-screens (portals, initiator groups, LUNs, …) disappear.
5. Click `+` in either Samba or NFS to open the "new share" form, then go to Settings and toggle Read-only on — the open form should auto-close.
6. Turn Read-only off → all affordances return.
7. **Admin lock**: edit `/etc/cockpit-file-sharing.conf.json` and set e.g. `"nfs": { "readOnlyLocked": true, ... }`, then refresh Cockpit. Open Settings → the NFS read-only toggle is now non-interactive and the description reads "Locked: pinned via /etc/cockpit-file-sharing.conf.json (nfs.readOnlyLocked = true)". The toggle still reflects the current `readOnly` value; the UI just can't change it.

---

## Follow-up work (out of scope here)

- **UI convenience umbrella**: a single "View-only across all tabs" toggle that fans out into the three per-tab booleans. Minor refactor; deferred to keep this PR focused.
- **Per-share read-only override**: e.g. "this share is managed by Ansible, lock the edit affordances even when the rest of the tab is editable". Useful but more invasive — needs a share-metadata schema decision.
- **Read-only banner**: a subtle "(read-only)" indicator in the tab header so operators don't have to inspect settings to know why the buttons are missing. Easy follow-up.
- **iSCSI deep editor wiring**: explicit `<fieldset :disabled>` on each editor's inputs, mirroring the NFS/Samba pattern. The existing `canEditIscsi` gate covers the write path; this would belt-and-braces the per-field disabled state.
