### PR TITLE
NFS: allow `sec=` in export client options validator

### DIFF
--- a/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
+++ b/file-sharing/src/tabs/nfs/ui/NFSExportEditor.vue
@@ -133,7 +133,7 @@ const allowedClientSettings = {
     "all_squash",
     "no_all_squash",
   ],
-  argumentOpts: ["mountpoint", "mp", "fsid", "refer", "replicas", "anonuid", "anongid"],
+  argumentOpts: ["mountpoint", "mp", "fsid", "refer", "replicas", "anonuid", "anongid", "sec"],
 };
 
 const clientOptionsValidator = (optionList: string): ValidationResult => {


### PR DESCRIPTION
## Summary
`allowedClientSettings.argumentOpts` in `NFSExportEditor.vue` didn't list `sec`, so any `/etc/exports` line containing `sec=sys` (the default flavor, often written explicitly) or `sec=krb5*` was rejected by the editor on read — blocking inspection of an otherwise perfectly valid export.

`sec=` is documented in `exports(5)` and accepts colon-delimited modes (`sys`, `krb5`, `krb5i`, `krb5p`). The existing `startsWith("sec=")` match in the validator already handles the multi-mode form, so adding `sec` to the allowlist is sufficient.

## Test plan
- [ ] Open an NFS export whose clients have `sec=sys` in their settings → no longer triggers `Bad options: "sec=sys"`.
- [ ] Open an NFS export with `sec=krb5:krb5i` → also accepted.
- [ ] An unknown option (e.g. `bogus_opt`) still surfaces as `Bad options`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)