### PR TITLE
Rgw pool creation bug

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -2,7 +2,7 @@ name: Build Packages
 on:
   push:
     branches: 
-      - build
+      - rgw-pool-creation-bug
     tags:
       - 'v*.*.*'
 jobs:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -2,7 +2,7 @@ name: Build Packages
 on:
   push:
     branches: 
-      - rgw-pool-creation-bug
+      - build
     tags:
       - 'v*.*.*'
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## Cockpit File Sharing 4.5.7-2
+## Cockpit File Sharing 4.5.8-1
 
-* added python3-venv dependency for ubuntu in manifest.
+* fix: prevent .rgw.root pool creation on clusters without RGW through s3 module

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PLUGIN_SRCS=file-sharing
 
 # For installing to a remote machine for testing with `make install-remote`
 # REMOTE_TEST_HOST=192.168.206.100
-REMOTE_TEST_HOST=192.168.207.11
+REMOTE_TEST_HOST=192.168.100.1
 REMOTE_TEST_USER=root
 # Restarts cockpit after install
 RESTART_COCKPIT?=0

--- a/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
+++ b/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
@@ -47,11 +47,7 @@ export async function listBucketsFromCeph(): Promise<CephBucket[]> {
 
 export async function isCephRgwHealthy(): Promise<boolean> {
   try {
-    // Any lightweight admin call that fails fast if RGW is unreachable/unauthorized
-    await rgwJson(["zonegroup", "get"]);
-    await ensureRgwUserExists({uid: "houstonUi",displayName: "Houston UI",systemUser: false,
-    });
-    return true;
+    return (await firstWorkingRgwGateway()) !== null;
   } catch (e) {
     return false;
   }
@@ -1222,7 +1218,7 @@ async function rgwUserExists(uid: string, tenant?: string): Promise<boolean> {
     return false;
   }
 }
-async function ensureRgwUserExists(opts: {uid: string;tenant?: string;displayName: string;systemUser?: boolean;maxBuckets?: number;suspended?: boolean;
+export async function ensureRgwUserExists(opts: {uid: string;tenant?: string;displayName: string;systemUser?: boolean;maxBuckets?: number;suspended?: boolean;
 }): Promise<void> {
   const exists = await rgwUserExists(opts.uid, opts.tenant);
   if (exists) return;

--- a/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
+++ b/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
@@ -141,15 +141,14 @@ async function resolveIpv4ViaGetent(hostname: string): Promise<string | null> {
   return ip ? ip : null;
 }
 
-async function httpProbeViaCurl(endpointUrl: string, timeoutSec = 1, insecure = false): Promise<boolean> {
+async function httpProbeViaCurl(endpointUrl: string, timeoutSec = 1): Promise<boolean> {
   const url = String(endpointUrl ?? "").trim();
   if (!url) return false;
 
-  const insecureFlag = insecure ? "-k " : "";
   const rc = await execText([
     "bash",
     "-lc",
-    `command -v curl >/dev/null 2>&1 || { echo "nocurl"; exit 0; }; curl -sS ${insecureFlag}-m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
+    `command -v curl >/dev/null 2>&1 || { echo "nocurl"; exit 0; }; curl -sS -m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
   ]);
 
   // If curl is not installed, we cannot verify the endpoint — report it as unreachable
@@ -196,7 +195,7 @@ async function firstWorkingRgwGateway(): Promise<RgwGateway | null> {
 
     const scheme = parsed.ssl ? "https" : "http";
     const endpoint = `${scheme}://${host}:${port}`;
-    const ok = await httpProbeViaCurl(endpoint, 1, parsed.ssl);
+    const ok = await httpProbeViaCurl(endpoint, 1);
     if (!ok) continue;
 
     return { id, hostname, zonegroup, zone, endpoint, isDefault };

--- a/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
+++ b/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
@@ -84,26 +84,45 @@ async function execText(
   }
 }
 
-function parseRgwFrontend(frontendConfig: string): { host?: string; port: number } | null {
+function parseRgwFrontend(frontendConfig: string): { host?: string; port: number; ssl?: boolean } | null {
+  const config = frontendConfig || "";
+
+  // Detect SSL: ssl_endpoint, ssl_port, or ssl_certificate present
+  const hasSsl = /\bssl_endpoint=|\bssl_port=|\bssl_certificate=/.test(config);
+
+  // Matches: "beast ssl_endpoint=192.168.85.64:443"
+  const sslEndpoint = config.match(/\bssl_endpoint=(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})\b/);
+  if (sslEndpoint && sslEndpoint[1] && sslEndpoint[2]) {
+    const port = Number(sslEndpoint[2]);
+    if (Number.isFinite(port) && port > 0 && port < 65536) return { host: sslEndpoint[1], port, ssl: true };
+  }
+
+  // Matches: "beast ssl_port=443"
+  const sslPortOnly = config.match(/\bssl_port=(\d{1,5})\b/);
+  if (sslPortOnly && sslPortOnly[1]) {
+    const port = Number(sslPortOnly[1]);
+    if (Number.isFinite(port) && port > 0 && port < 65536) return { port, ssl: true };
+  }
+
   // Matches: "beast endpoint=192.168.85.64:8080"
-  const endpoint = frontendConfig.match(/\bendpoint=(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})\b/);
+  const endpoint = config.match(/\bendpoint=(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})\b/);
   if (endpoint && endpoint[1] && endpoint[2]) {
     const port = Number(endpoint[2]);
-    if (Number.isFinite(port) && port > 0 && port < 65536) return { host: endpoint[1], port };
+    if (Number.isFinite(port) && port > 0 && port < 65536) return { host: endpoint[1], port, ssl: hasSsl };
   }
 
   // Matches: "beast port=192.168.45.230:8080"
-  const portIp = frontendConfig.match(/\bport=(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})\b/);
+  const portIp = config.match(/\bport=(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})\b/);
   if (portIp && portIp[1] && portIp[2]) {
     const port = Number(portIp[2]);
-    if (Number.isFinite(port) && port > 0 && port < 65536) return { host: portIp[1], port };
+    if (Number.isFinite(port) && port > 0 && port < 65536) return { host: portIp[1], port, ssl: hasSsl };
   }
 
   // Matches: "beast port=8080"
-  const portOnly = frontendConfig.match(/\bport=(\d{1,5})\b/);
+  const portOnly = config.match(/\bport=(\d{1,5})\b/);
   if (portOnly && portOnly[1]) {
     const port = Number(portOnly[1]);
-    if (Number.isFinite(port) && port > 0 && port < 65536) return { port };
+    if (Number.isFinite(port) && port > 0 && port < 65536) return { port, ssl: hasSsl };
   }
 
   return null;
@@ -122,16 +141,19 @@ async function resolveIpv4ViaGetent(hostname: string): Promise<string | null> {
   return ip ? ip : null;
 }
 
-async function httpProbeViaCurl(endpointUrl: string, timeoutSec = 1): Promise<boolean> {
+async function httpProbeViaCurl(endpointUrl: string, timeoutSec = 1, insecure = false): Promise<boolean> {
   const url = String(endpointUrl ?? "").trim();
   if (!url) return false;
 
+  const insecureFlag = insecure ? "-k " : "";
   const rc = await execText([
     "bash",
     "-lc",
-    `curl -sS -m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
+    `command -v curl >/dev/null 2>&1 || { echo "nocurl"; exit 0; }; curl -sS ${insecureFlag}-m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
   ]);
 
+  // If curl is not installed, we cannot verify the endpoint — report it as unreachable
+  if (rc === "nocurl") return false;
   return rc === "0";
 }
 
@@ -172,8 +194,9 @@ async function firstWorkingRgwGateway(): Promise<RgwGateway | null> {
       host = ip;
     }
 
-    const endpoint = `http://${host}:${port}`;
-    const ok = await httpProbeViaCurl(endpoint, 1);
+    const scheme = parsed.ssl ? "https" : "http";
+    const endpoint = `${scheme}://${host}:${port}`;
+    const ok = await httpProbeViaCurl(endpoint, 1, parsed.ssl);
     if (!ok) continue;
 
     return { id, hostname, zonegroup, zone, endpoint, isDefault };

--- a/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
+++ b/file-sharing/src/tabs/s3Management/api/cephCliAdapter.ts
@@ -148,7 +148,7 @@ async function httpProbeViaCurl(endpointUrl: string, timeoutSec = 1): Promise<bo
   const rc = await execText([
     "bash",
     "-lc",
-    `command -v curl >/dev/null 2>&1 || { echo "nocurl"; exit 0; }; curl -sS -m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
+    `command -v curl >/dev/null 2>&1 || { echo "nocurl"; exit 0; }; curl -sSk -m ${timeoutSec} -o /dev/null "${url}/" >/dev/null 2>&1; echo $?`,
   ]);
 
   // If curl is not installed, we cannot verify the endpoint — report it as unreachable

--- a/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
+++ b/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
@@ -199,6 +199,7 @@ import { ArchiveBoxIcon, ArrowPathIcon } from "@heroicons/vue/20/solid";
 import AccIcon from "../images/AccIcon.vue";
 import type { RgwGateway } from "../types/types";
 import { pushNotification, Notification, confirm } from "@45drives/houston-common-ui";
+import { unwrap } from "@45drives/houston-common-lib";
 
 type Backend = "minio" | "rustfs" | "ceph" | "garage";
 type View = "buckets" | "users";

--- a/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
+++ b/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
@@ -175,7 +175,7 @@
 import { ref, computed, onMounted, watch } from "vue";
 import S3BucketsView from "./bucketManagement/S3BucketsView.vue";
 import RustfsInstanceSelector from "./RustfsInstanceSelector.vue";
-import { isCephRgwHealthy, listRgwGateways } from "../api/cephCliAdapter";
+import { isCephRgwHealthy, listRgwGateways, ensureRgwUserExists } from "../api/cephCliAdapter";
 import {
   isMinioAvailable,
   listMinioAliasCandidates,
@@ -198,7 +198,7 @@ import { CardContainer } from "@45drives/houston-common-ui";
 import { ArchiveBoxIcon, ArrowPathIcon } from "@heroicons/vue/20/solid";
 import AccIcon from "../images/AccIcon.vue";
 import type { RgwGateway } from "../types/types";
-import { pushNotification, Notification } from "@45drives/houston-common-ui";
+import { pushNotification, Notification, confirm } from "@45drives/houston-common-ui";
 
 type Backend = "minio" | "rustfs" | "ceph" | "garage";
 type View = "buckets" | "users";
@@ -603,13 +603,33 @@ async function chooseBackend(backend: Backend) {
   step.value = 2;
 }
 
-function chooseView(view: View) {
+async function chooseView(view: View) {
   if (selectedBackend.value === "rustfs" && view === "users") {
     const alias = selectedRustfsAlias.value.trim();
     if (!alias) return;
     // Reuse MinIO access-management command layer against selected RustFS alias.
     setMinioAlias(alias);
   }
+
+  // Ensure houstonUi RGW user exists before entering bucket management for Ceph
+  if (selectedBackend.value === "ceph" && view === "buckets") {
+    const proceed = await confirm({
+      header: "Ceph RGW Service User",
+      body: "A 'houstonUi' service user is required for bucket operations. It will be created on Ceph RGW if it does not already exist. Press OK to proceed.",
+      confirmButtonText: "OK",
+      cancelButtonText: "Cancel",
+    });
+
+    if (proceed.isErr() || !proceed.value) return;
+
+    try {
+      await ensureRgwUserExists({uid: "houstonUi", displayName: "Houston UI", systemUser: false});
+    } catch (e: any) {
+      pushNotification(new Notification("Ceph RGW", `Failed to create houstonUi service user: ${e?.message}`, "error"));
+      return;
+    }
+  }
+
   selectedView.value = view;
   step.value = 3;
 }

--- a/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
+++ b/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
@@ -620,12 +620,16 @@ async function chooseView(view: View) {
       cancelButtonText: "Cancel",
     });
 
-    if (proceed.isErr() || !proceed.value) return;
+    if (proceed.isErr()) {
+      pushNotification(new Notification("Ceph RGW", "Could not display confirmation dialog. Please try again.", "error"));
+      return;
+    }
+    if (!proceed.value) return; // user cancelled
 
     try {
       await ensureRgwUserExists({uid: "houstonUi", displayName: "Houston UI", systemUser: false});
     } catch (e: any) {
-      pushNotification(new Notification("Ceph RGW", `Failed to create houstonUi service user: ${e?.message}`, "error"));
+      pushNotification(new Notification("Ceph RGW", `Failed to create houstonUi service user: ${e?.message ?? String(e) ?? "Unknown error"}`, "error"));
       return;
     }
   }

--- a/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
+++ b/file-sharing/src/tabs/s3Management/ui/S3ManagementMain.vue
@@ -613,18 +613,14 @@ async function chooseView(view: View) {
 
   // Ensure houstonUi RGW user exists before entering bucket management for Ceph
   if (selectedBackend.value === "ceph" && view === "buckets") {
-    const proceed = await confirm({
+    const proceed = await unwrap(confirm({
       header: "Ceph RGW Service User",
       body: "A 'houstonUi' service user is required for bucket operations. It will be created on Ceph RGW if it does not already exist. Press OK to proceed.",
       confirmButtonText: "OK",
       cancelButtonText: "Cancel",
-    });
+    }));
 
-    if (proceed.isErr()) {
-      pushNotification(new Notification("Ceph RGW", "Could not display confirmation dialog. Please try again.", "error"));
-      return;
-    }
-    if (!proceed.value) return; // user cancelled
+    if (!proceed) return; // user cancelled
 
     try {
       await ensureRgwUserExists({uid: "houstonUi", displayName: "Houston UI", systemUser: false});

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,9 @@
     "name": "cockpit-file-sharing",
     "title": "Cockpit File Sharing",
     "description": "A cockpit module to make file sharing with Samba and NFS easier.",
-    "version": "4.5.7",
-    "build_number": "2",
-    "stable": true,
+    "version": "4.5.8",
+    "build_number": "1",
+    "stable": false,
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "git_url": "https://github.com/45Drives/cockpit-file-sharing",
     "license": "GPL-3.0+",
@@ -81,8 +81,8 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "4.5.7",
-        "build_number": "2",
+        "version": "4.5.8",
+        "build_number": "1",
         "date": null,
         "packager": "Josh Boudreau <jboudreau@45drives.com>",
         "changes": []

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
         "ubuntu_common": [
             "cockpit-bridge",
             "coreutils",
+            "curl",
             "attr",
             "findutils",
             "hostname",
@@ -36,6 +37,7 @@
         "rocky_common": [
             "cockpit-bridge",
             "coreutils",
+            "curl",
             "attr",
             "findutils",
             "hostname",

--- a/packaging/debian-bookworm/changelog
+++ b/packaging/debian-bookworm/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (4.5.8-1bookworm) bookworm; urgency=medium
+
+  * fix: prevent .rgw.root pool creation on clusters without RGW through s3 module
+
+ -- Rachit Hans <rhans@45drives.com>  Mon, 25 May 2026 15:07:35 -0300
+
 cockpit-file-sharing (4.5.7-2bookworm) bookworm; urgency=medium
 
   * added python3-venv dependency for ubuntu in manifest.

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -37,6 +37,8 @@ fi
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Mon May 25 2026 Rachit Hans <rhans@45drives.com> 4.5.8-1
+- fix: prevent .rgw.root pool creation on clusters without RGW through s3 module
 * Thu May 14 2026 Rachit Hans <rhans@45drives.com> 4.5.7-2
 - added python3-venv dependency for ubuntu in manifest.
 * Thu May 14 2026 Rachit Hans <rhans@45drives.com> 4.5.7-1

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -37,6 +37,8 @@ fi
 /usr/share/cockpit/file-sharing/*
 
 %changelog
+* Mon May 25 2026 Rachit Hans <rhans@45drives.com> 4.5.8-1
+- fix: prevent .rgw.root pool creation on clusters without RGW through s3 module
 * Thu May 14 2026 Rachit Hans <rhans@45drives.com> 4.5.7-2
 - added python3-venv dependency for ubuntu in manifest.
 * Thu May 14 2026 Rachit Hans <rhans@45drives.com> 4.5.7-1

--- a/packaging/ubuntu-focal/changelog
+++ b/packaging/ubuntu-focal/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (4.5.8-1focal) focal; urgency=medium
+
+  * fix: prevent .rgw.root pool creation on clusters without RGW through s3 module
+
+ -- Rachit Hans <rhans@45drives.com>  Mon, 25 May 2026 15:07:35 -0300
+
 cockpit-file-sharing (4.5.7-2focal) focal; urgency=medium
 
   * added python3-venv dependency for ubuntu in manifest.

--- a/packaging/ubuntu-jammy/changelog
+++ b/packaging/ubuntu-jammy/changelog
@@ -1,3 +1,9 @@
+cockpit-file-sharing (4.5.8-1jammy) jammy; urgency=medium
+
+  * fix: prevent .rgw.root pool creation on clusters without RGW through s3 module
+
+ -- Rachit Hans <rhans@45drives.com>  Mon, 25 May 2026 15:07:35 -0300
+
 cockpit-file-sharing (4.5.7-2jammy) jammy; urgency=medium
 
   * added python3-venv dependency for ubuntu in manifest.


### PR DESCRIPTION
**Summary**
Fixes an issue where opening S3-related UI paths could create the Ceph [.rgw.root](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) pool on systems without RGW enabled, which led to cluster health warnings and could impact other File Sharing UI operations.

**Root cause**
S3 backend detection called radosgw-admin during health checks.
On clusters without active RGW daemons, this call can have side effects (pool creation), and in unhealthy cluster states it can also stall long enough to hold global UI processing state.

**What changed**

- Updated Ceph S3 health detection to use daemon/service discovery (no side-effectful radosgw-admin call during detection).
- Moved houstonUi RGW service-user creation out of passive detection and into explicit user flow (bucket management entry).
- Added explicit user confirmation before creating the RGW service user.
- Added clear failure handling so bucket flow does not proceed silently if service-user provisioning fails.
-
**Why this fixes it**

- No side-effectful RGW admin command is executed during tab/backend detection.
- [.rgw.root]  is no longer auto-created on non-RGW systems just by opening File Sharing/S3 UI.
- Prevents S3 detection from unnecessarily contributing to global UI blocking behavior.